### PR TITLE
fix: defeat Duck Detector "generate-mode fingerprint" probe

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -1123,7 +1123,12 @@ private fun KeyMintAttestation.toAuthorizations(
         }
         return Authorization().apply {
             this.keyParameter = param
-            this.securityLevel = SecurityLevel.SOFTWARE
+            // Real KeyMint HAL marks keystore-enforced metadata (creation
+            // time, user id, etc.) with SecurityLevel.KEYSTORE (0x64), not
+            // SOFTWARE (0x00). Using SOFTWARE here is detectable by probes
+            // that scan the generateKey reply parcel for the 0x00 byte at
+            // the securityLevel slot of the last authorization entry.
+            this.securityLevel = SecurityLevel.KEYSTORE
         }
     }
 


### PR DESCRIPTION
## Problem

Duck Detector's "TEE Simulator generate-mode fingerprint" probe scans the
`generateKey` binder reply parcel for a 16-byte marker. The discriminator is
the `securityLevel` byte in the last Authorization entry: real hardware writes
`0x64` (KEYSTORE=100), TEESimulator writes `0x00` (SOFTWARE=0).

## Fix

Use `SecurityLevel.KEYSTORE` instead of `SecurityLevel.SOFTWARE` in
`createSwAuth()`. This matches what real KeyMint HAL does for keystore-enforced
metadata (creation time, user ID, expiry, etc.).

## Result

| Metric | Before | After |
|---|---|---|
| Detection | `Matched` | `No fingerprint observed` |
| Tamper score | 50 | 4 |
| Verdict | TAMPERED | CONSISTENT |

Tested on OnePlus 13 (Snapdragon 8 Elite, Android 16, KSU 3.2.4).

## Reference

Detection logic source: https://github.com/eltavine/Duck-Detector-Refactoring/commit/e368038


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed security level reporting for keystore-enforced metadata to accurately reflect system capabilities and match actual security enforcement behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Enginex0/TEESimulator-RS/pull/21)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->