### PR TITLE
fix(intercept): use ContinueAndSkipPost for KEY_ID createOperation NOT FOUND

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -317,7 +317,7 @@ class KeyMintSecurityLevelInterceptor(
                     entry ?: run {
                         trackAndEnforceOpLimit(callingUid, txId)?.let { return it }
                         SystemLogger.info("[TX_ID: $txId] createOperation KeyId(${keyDescriptor.nspace}) NOT FOUND for uid=$callingUid. Forwarding to HAL.")
-                        return TransactionResult.Continue
+                        return TransactionResult.ContinueAndSkipPost
                     }
                 }
                 else -> {


### PR DESCRIPTION
When handleCreateOperation receives a Domain.KEY_ID request for a key not in our generatedKeys cache, it correctly forwards to the real HAL. However, it previously returned TransactionResult.Continue, which lets the post-handler run. The post-handler unconditionally registers an OperationInterceptor on the IKeystoreOperation binder returned by real keystore2. This interceptor then interferes with the caller's operation (intercepting finish/abort/updateAad calls).

On devices where vendor daemons (e.g. fingerprint calibration) use Domain.KEY_ID for their hardware-backed keys, this causes operation failures.

Fix: return ContinueAndSkipPost (matching the existing Domain.APP NOT FOUND path) so the post-handler never runs for operations on keys we don't own.

Symptom: OnePlus engineering mode ultrasonic fingerprint calibration hash retrieval fails with module enabled, works with module disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key operation handling by preventing post-operation logic from executing when a requested key identifier cannot be resolved, enhancing system efficiency and reducing unnecessary processing in error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Enginex0/TEESimulator-RS/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->