### PR TITLE
fix(interception): strip INCLUDE_UNIQUE_ID instead of rejecting when permission missing

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -434,8 +434,8 @@ class KeyMintSecurityLevelInterceptor(
                 SystemLogger.debug(
                     "Handling generateKey ${keyDescriptor.alias}, attestKey=${attestationKey?.alias}"
                 )
-                val params = data.createTypedArray(KeyParameter.CREATOR)!!
-                val parsedParams = KeyMintAttestation(params)
+                var params = data.createTypedArray(KeyParameter.CREATOR)!!
+                var parsedParams = KeyMintAttestation(params)
                 val isAttestKeyRequest = parsedParams.isAttestKey()
 
                 if (ConfigurationManager.shouldSkipUid(callingUid)
@@ -477,8 +477,16 @@ class KeyMintSecurityLevelInterceptor(
                     return InterceptorUtils.createErrorReply(KEYMINT_CANNOT_ATTEST_IDS)
                 }
 
-                // AOSP security_level.rs:478-485: INCLUDE_UNIQUE_ID requires
-                // SELinux gen_unique_id OR Android REQUEST_UNIQUE_ID_ATTESTATION
+                // INCLUDE_UNIQUE_ID requires SELinux gen_unique_id OR
+                // android.permission.REQUEST_UNIQUE_ID_ATTESTATION (AOSP
+                // security_level.rs:478-485). AOSP returns PERMISSION_DENIED
+                // when neither is held — but doing so breaks Google Wallet
+                // card binding (Wallet's generateKey carries the tag without
+                // holding the permission, and Play Integrity also fails when
+                // unique_id ends up in the attestation). Silently strip the
+                // tag so the key generates normally and the resulting
+                // attestation simply omits the unique_id field. This mirrors
+                // the pre-PR157 behavior where the tag had no effect.
                 if (params.any { it.tag == Tag.INCLUDE_UNIQUE_ID }) {
                     val hasSELinux = ConfigurationManager.checkSELinuxPermission(
                         callingPid, "keystore_key", "gen_unique_id",
@@ -487,8 +495,9 @@ class KeyMintSecurityLevelInterceptor(
                         callingUid, "android.permission.REQUEST_UNIQUE_ID_ATTESTATION",
                     )
                     if (!hasSELinux && !hasAndroid) {
-                        SystemLogger.warning("[TX_ID: $txId] Rejecting INCLUDE_UNIQUE_ID for uid=$callingUid pid=$callingPid")
-                        return InterceptorUtils.createServiceSpecificErrorReply(RESPONSE_PERMISSION_DENIED)
+                        SystemLogger.debug("[TX_ID: $txId] Stripping INCLUDE_UNIQUE_ID for uid=$callingUid pid=$callingPid (no permission)")
+                        params = params.filter { it.tag != Tag.INCLUDE_UNIQUE_ID }.toTypedArray()
+                        parsedParams = KeyMintAttestation(params)
                     }
                 }
 


### PR DESCRIPTION
## Summary

The `INCLUDE_UNIQUE_ID` permission gate in `handleGenerateKey` rejects
the entire `generateKey` call with `PERMISSION_DENIED` when the caller
holds neither SELinux `gen_unique_id` nor
`REQUEST_UNIQUE_ID_ATTESTATION`. This breaks Google Wallet on real
devices: Wallet's attestation key request carries `INCLUDE_UNIQUE_ID`
without the permission, so the request is rejected and Wallet shows
"this phone does not meet the security requirements for Google Wallet".
Clearing GMS data only helps for a few seconds.

## Why this fix instead of removing the gate

Naive removal regresses Play Integrity to three-red. `AttestationBuilder`
honours `includeUniqueId == true` by computing an HMAC-SHA256
`unique_id` and embedding it in the attestation extension. With the
gate removed, GMS attestation flows pick the tag through and the
extension ends up with a `unique_id` that the integrity server flags as
inconsistent for the caller.

## Approach

When the permission check fails, silently strip `INCLUDE_UNIQUE_ID` from
the `KeyParameter[]` (and re-parse `parsedParams`) instead of rejecting.
The key generates normally, `AttestationBuilder` falls through to
`else { ByteArray(0) }`, and the resulting attestation simply omits the
`unique_id` field. This matches pre-PR157 behaviour, where the tag had
no effect.

Calls that **do** hold the permission are unaffected — `unique_id` is
still emitted as before.

## Verification

Tested on a device that previously failed Wallet binding on the PR157
baseline:
- Play Integrity: BASIC + DEVICE + STRONG all pass.
- Google Wallet: card binding completes successfully.
- Other PR157 compliance work (CALLER_NONCE, AuthorizeCreate ordering,
  USAGE_COUNT_LIMIT counters, effectiveParams merging) untouched.

## Bisect

The regression was bisected commit-by-commit between `v5.0-138` and
`v5.1-153`; isolated to commit 8eda2d8
("feat(interception): add AOSP authorize_create enforcement and wire
format fixes"); within that commit, narrowed to the
`INCLUDE_UNIQUE_ID` gate specifically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Key generation now handles unique-ID attestation requests more gracefully: when required permissions are missing, the system logs the condition, removes the unique-ID request, and proceeds rather than rejecting the operation.
  * The processing of key parameters can be adjusted during handling so attestation settings are re-evaluated after modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Enginex0/TEESimulator-RS/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->