### PR TITLE
fix: skip StrongBox op limit for forwarded HAL operations

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -385,9 +385,6 @@ class KeyMintSecurityLevelInterceptor(
                                         .find { it.value.nspace == nspace }
                             entry
                                 ?: run {
-                                    trackAndEnforceOpLimit(callingUid, txId)?.let {
-                                        return it
-                                    }
                                     SystemLogger.info(
                                         "[TX_ID: $txId] createOperation KeyId(${keyDescriptor.nspace}) NOT FOUND for uid=$callingUid. Forwarding to HAL."
                                     )


### PR DESCRIPTION
Fixes #39. Do not apply trackAndEnforceOpLimit to Domain.KEY_ID operations that are not found in generatedKeys, allowing legitimate hardware StrongBox requests to pass through to the real HAL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of key operations when a generated key entry cannot be found.
  * Ensured operation-limit checks are applied consistently without affecting fallback forwarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->