### PR TITLE
fix(spoof): cover Xiaomi secure-boot aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Controls global `ro.boot.*` property spoofing. Values: `auto` (default), `force`
 
 In `auto`, Oplus-family devices (OnePlus/OPPO/realme/Oplus) skip boot-state prop spoofing to avoid conflicts with vendor TEE services such as ultrasonic fingerprint calibration. Create `/data/adb/tricky_store/boot_props_mode` with `force` to restore the old behavior, or `disable` to turn it off on any device.
 
+On Xiaomi/Redmi/Poco devices, the module also normalizes the vendor `ro.secureboot.*` aliases when they exist. This prevents `ro.secureboot.lockstate` from continuing to report `unlocked` after the standard AVB properties have been spoofed.
+
 ## Building from source
 
 You need JDK 21, the Android SDK and NDK 29, Rust (stable) with the `aarch64-linux-android` target, and `cargo-ndk`.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     compileOnly(project(":stub"))
     compileOnly(libs.annotation)
     implementation(libs.bcpkix)
+    testImplementation(libs.junit)
 }
 
 // --- Rust native cert gen build task ---
@@ -239,6 +240,31 @@ androidComponents {
                                 "\nallow keystore media_rw_data_file { dir file } *" +
                                     "\nallow platform_app media_rw_data_file { dir file } *\n",
                             )
+                    }
+                }
+
+                doLast {
+                    // Android module installers and shells reject CRLF scripts from Windows checkouts.
+                    val unixTextFiles =
+                        listOf(
+                            "customize.sh",
+                            "service.sh",
+                            "action.sh",
+                            "action_i18n.sh",
+                            "uninstall.sh",
+                            "diag.sh",
+                            "daemon",
+                            "META-INF/com/google/android/update-binary",
+                            "META-INF/com/google/android/updater-script",
+                        )
+
+                    unixTextFiles.forEach { relativePath ->
+                        val file = tempModuleDir.get().asFile.resolve(relativePath)
+                        if (file.isFile) {
+                            val normalized =
+                                file.readText().replace("\r\n", "\n").replace("\r", "\n")
+                            file.writeText(normalized)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/org/matrix/TEESimulator/config/BootStateManager.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/config/BootStateManager.kt
@@ -15,12 +15,16 @@ object BootStateManager {
         DISABLE,
     }
 
-    private val targets =
+    internal val targetOverrides: Map<String, String> =
         linkedMapOf(
             "ro.boot.verifiedbootstate" to "green",
             "ro.boot.flash.locked" to "1",
             "ro.boot.veritymode" to "enforcing",
             "ro.boot.vbmeta.device_state" to "locked",
+            // Xiaomi/MediaTek also publish the bootloader state outside the ro.boot namespace.
+            "ro.boot.secureboot" to "1",
+            "ro.secureboot.devicelock" to "1",
+            "ro.secureboot.lockstate" to "locked",
         )
 
     private val fillIfAbsent =
@@ -51,7 +55,7 @@ object BootStateManager {
             }
         }
 
-        for ((name, target) in targets) {
+        for ((name, target) in targetOverrides) {
             val current = SystemProperties.get(name, "")
             if (current.isEmpty()) {
                 SystemLogger.debug("BootStateManager: $name absent on this device, skip")

--- a/app/src/test/java/org/matrix/TEESimulator/config/BootStateManagerTest.kt
+++ b/app/src/test/java/org/matrix/TEESimulator/config/BootStateManagerTest.kt
@@ -1,0 +1,13 @@
+package org.matrix.TEESimulator.config
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BootStateManagerTest {
+    @Test
+    fun `covers Xiaomi secure boot aliases`() {
+        assertEquals("1", BootStateManager.targetOverrides["ro.boot.secureboot"])
+        assertEquals("1", BootStateManager.targetOverrides["ro.secureboot.devicelock"])
+        assertEquals("locked", BootStateManager.targetOverrides["ro.secureboot.lockstate"])
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,14 @@
 agp = "8.13.2"
 annotation = "1.9.1"
 jdk18on = "1.83"
+junit = "4.13.2"
 kotlin = "2.3.0"
 ktfmt = "0.25.0"
 
 [libraries]
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 bcpkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "jdk18on" }
+junit = { module = "junit:junit", version.ref = "junit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/module/changelog.md
+++ b/module/changelog.md
@@ -3,6 +3,30 @@
 
 ---
 
+## TEESimulator-RS v6.0.1-309
+
+Fixes Xiaomi/Redmi/Poco bootloader-state disclosure through vendor system-property aliases.
+
+### Boot-state spoofing
+- Xiaomi/Redmi/Poco vendor aliases are now normalized alongside the standard AVB properties. In particular, `ro.secureboot.lockstate` no longer remains `unlocked` while `ro.boot.flash.locked` and `ro.boot.vbmeta.device_state` report a locked device.
+- Windows builds now normalize module installer and shell scripts to LF so KernelSU/Magisk can execute them.
+
+### Verified
+- On a Redmi Android 14 device, the standard AVB and Xiaomi secure-boot properties all report a consistent locked/green state after applying the new overrides.
+
+### 中文说明
+
+修复 Xiaomi/Redmi/Poco 通过厂商系统属性别名泄露 bootloader 解锁状态的问题。
+
+**启动状态伪装**
+- Xiaomi/Redmi/Poco 的厂商属性别名现在会与标准 AVB 属性一起归一化，避免 `ro.boot.flash.locked` 和 `ro.boot.vbmeta.device_state` 已显示锁定时，`ro.secureboot.lockstate` 仍泄露 `unlocked`。
+- Windows 环境打包时会将模块安装器和 Shell 脚本统一为 LF 换行，确保 KernelSU/Magisk 可以正常执行。
+
+**验证**
+- 已在 Redmi Android 14 设备上验证：应用新增覆盖后，标准 AVB 与 Xiaomi secure-boot 属性均一致报告 locked/green。
+
+---
+
 ## TEESimulator-RS v6.0.1-307
 
 Fixes five gaps in the module's TEE key-operation and attestation emulation. Two of them fix crashes in real app crypto on a broken-TEE device: any app using an AndroidKeyStore HMAC key or an RSA-OAEP-SHA256 key was throwing. This is a beta; the confirmation logs are in the debug build only, and nothing is field-verified yet.


### PR DESCRIPTION
## Summary
- normalize Xiaomi/Redmi/Poco secure-boot aliases together with standard AVB properties
- add a focused regression test for the complete boot-state override map
- normalize flashable module scripts to LF during Windows builds

## Validation
- `:app:testDebugUnitTest` passes
- `zipRelease zipDebug` passes; all packaged installer/shell scripts contain zero CRLF sequences
- KernelSU installs v6.0.1-309 successfully and the module remains active after reboot
- Redmi Android 14 reports `ro.boot.flash.locked=1`, `ro.boot.vbmeta.device_state=locked`, `ro.boot.verifiedbootstate=green`, and `ro.secureboot.lockstate=locked`
- Key Attestation v1.8.4 reports `deviceLocked=true` and `verifiedBootState=Verified`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootloader-state reporting on Xiaomi, Redmi, and Poco devices by normalizing secure-boot properties.
  * Ensured packaged scripts use consistent Unix line endings for improved compatibility.
  * Verified consistent locked/green attestation properties on Redmi devices running Android 14.

* **Documentation**
  * Updated boot property mode documentation and added English and Chinese release notes.

* **Tests**
  * Added coverage for Xiaomi secure-boot property overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->