### PR TITLE
Fix: Fix StrongBox operation limiter counting completed operations

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -24,7 +24,7 @@ import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
 import org.matrix.TEESimulator.attestation.AttestationBuilder
 import org.matrix.TEESimulator.attestation.AttestationConstants
@@ -61,7 +61,22 @@ class KeyMintSecurityLevelInterceptor(
     )
 
     private val activeOps = ConcurrentHashMap<Int, ConcurrentLinkedDeque<SoftwareOperation>>()
-    private val recentOps = ConcurrentHashMap<Int, ConcurrentLinkedDeque<Long>>()
+    private val strongBoxOps = ConcurrentHashMap<Int, StrongBoxUidState>()
+    private val pendingStrongBoxOps = ConcurrentHashMap<Long, StrongBoxOpSlot>()
+
+    private data class StrongBoxUidState(var inFlight: Int = 0)
+
+    private inner class StrongBoxOpSlot(private val uid: Int) {
+        private val released = AtomicBoolean(false)
+
+        fun release() {
+            if (!released.compareAndSet(false, true)) return
+            strongBoxOps.computeIfPresent(uid) { _, state ->
+                state.inFlight--
+                if (state.inFlight == 0) null else state
+            }
+        }
+    }
 
     override fun onPreTransact(
         txId: Long,
@@ -119,8 +134,12 @@ class KeyMintSecurityLevelInterceptor(
         reply: Parcel?,
         resultCode: Int,
     ): TransactionResult {
-        if (resultCode != 0 || reply == null || InterceptorUtils.hasException(reply))
+        if (resultCode != 0 || reply == null || InterceptorUtils.hasException(reply)) {
+            if (code == CREATE_OPERATION_TRANSACTION) {
+                pendingStrongBoxOps.remove(txId)?.release()
+            }
             return TransactionResult.SkipTransaction
+        }
 
         if (code == IMPORT_KEY_TRANSACTION) {
             logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
@@ -176,50 +195,67 @@ class KeyMintSecurityLevelInterceptor(
                 }
             }
         } else if (code == CREATE_OPERATION_TRANSACTION) {
-            logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
+            val strongBoxSlot = pendingStrongBoxOps.remove(txId)
+            var slotTransferred = false
+            try {
+                logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
 
-            data.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR)
-            val keyDescriptor =
-                data.readTypedObject(KeyDescriptor.CREATOR)
-                    ?: return TransactionResult.SkipTransaction
-            val params =
-                data.createTypedArray(KeyParameter.CREATOR)
-                    ?: return TransactionResult.SkipTransaction
-            val parsedParams = KeyMintAttestation(params)
-            val forced = data.readBoolean()
-            if (forced)
+                data.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR)
+                val keyDescriptor =
+                    data.readTypedObject(KeyDescriptor.CREATOR)
+                        ?: return TransactionResult.SkipTransaction
+                val params =
+                    data.createTypedArray(KeyParameter.CREATOR)
+                        ?: return TransactionResult.SkipTransaction
+                val parsedParams = KeyMintAttestation(params)
+                val forced = data.readBoolean()
+                if (forced)
+                    SystemLogger.verbose(
+                        "[TX_ID: $txId] Current operation has a very high pruning power."
+                    )
+                val response: CreateOperationResponse =
+                    reply.readTypedObject(CreateOperationResponse.CREATOR)
+                        ?: return TransactionResult.SkipTransaction
                 SystemLogger.verbose(
-                    "[TX_ID: $txId] Current operation has a very high pruning power."
+                    "[TX_ID: $txId] CreateOperationResponse: ${response.iOperation} ${response.operationChallenge}"
                 )
-            val response: CreateOperationResponse =
-                reply.readTypedObject(CreateOperationResponse.CREATOR)
-                    ?: return TransactionResult.SkipTransaction
-            SystemLogger.verbose(
-                "[TX_ID: $txId] CreateOperationResponse: ${response.iOperation} ${response.operationChallenge}"
-            )
 
-            // Intercept the IKeystoreOperation binder
-            response.iOperation?.let { operation ->
-                val operationBinder = operation.asBinder()
-                if (!interceptedOperations.containsKey(operationBinder)) {
-                    SystemLogger.info("Found new IKeystoreOperation. Registering interceptor...")
-                    val backdoor = getBackdoor(target)
-                    if (backdoor != null) {
-                        val isAead = parsedParams.blockMode.firstOrNull() == BlockMode.GCM
-                        val interceptor = OperationInterceptor(operation, backdoor, isAead)
-                        register(
-                            backdoor,
-                            operationBinder,
-                            interceptor,
-                            OperationInterceptor.INTERCEPTED_CODES,
-                        )
-                        interceptedOperations[operationBinder] = interceptor
-                    } else {
-                        SystemLogger.error(
-                            "Failed to get backdoor to register OperationInterceptor."
-                        )
+                // Intercept the IKeystoreOperation binder and hold the reserved StrongBox slot
+                // until the forwarded operation finishes or aborts.
+                response.iOperation?.let { operation ->
+                    val operationBinder = operation.asBinder()
+                    if (!interceptedOperations.containsKey(operationBinder)) {
+                        SystemLogger.info("Found new IKeystoreOperation. Registering interceptor...")
+                        val backdoor = getBackdoor(target)
+                        if (backdoor != null) {
+                            val isAead = parsedParams.blockMode.firstOrNull() == BlockMode.GCM
+                            val interceptor =
+                                OperationInterceptor(
+                                    operation,
+                                    backdoor,
+                                    isAead,
+                                    strongBoxSlot?.let { slot -> slot::release },
+                                )
+                            if (
+                                register(
+                                    backdoor,
+                                    operationBinder,
+                                    interceptor,
+                                    OperationInterceptor.INTERCEPTED_CODES,
+                                )
+                            ) {
+                                interceptedOperations[operationBinder] = interceptor
+                                slotTransferred = strongBoxSlot != null
+                            }
+                        } else {
+                            SystemLogger.error(
+                                "Failed to get backdoor to register OperationInterceptor."
+                            )
+                        }
                     }
                 }
+            } finally {
+                if (!slotTransferred) strongBoxSlot?.release()
             }
         } else if (code == GENERATE_KEY_TRANSACTION) {
             logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
@@ -320,24 +356,43 @@ class KeyMintSecurityLevelInterceptor(
         )
     }
 
-    private fun trackAndEnforceOpLimit(callingUid: Int, txId: Long): TransactionResult? {
-        if (securityLevel != SecurityLevel.STRONGBOX) return null
-        val inFlight = activeOps[callingUid]?.count { !it.finalized } ?: 0
-		if (inFlight >= STRONGBOX_MAX_CONCURRENT_OPS) {
+    private fun reserveStrongBoxOp(callingUid: Int, txId: Long): StrongBoxOpSlot? {
+        var slot: StrongBoxOpSlot? = null
+        var inFlight = 0
+        strongBoxOps.compute(callingUid) { _, current ->
+            val state = current ?: StrongBoxUidState()
+            if (state.inFlight < STRONGBOX_MAX_CONCURRENT_OPS) {
+                state.inFlight++
+                slot = StrongBoxOpSlot(callingUid)
+            }
+            inFlight = state.inFlight
+            state
+        }
+        if (slot == null) {
             SystemLogger.info(
                 "[TX_ID: $txId] StrongBox in-flight op limit reached for uid=$callingUid (active=$inFlight max=$STRONGBOX_MAX_CONCURRENT_OPS)"
             )
-            return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
         }
-        return null
+        return slot
+    }
+
+    private fun forwardCreateOperation(
+        txId: Long,
+        strongBoxSlot: StrongBoxOpSlot?,
+    ): TransactionResult {
+        if (strongBoxSlot == null) return TransactionResult.ContinueAndSkipPost
+        pendingStrongBoxOps.put(txId, strongBoxSlot)?.release()
+        return TransactionResult.Continue
     }
 
     private fun handleCreateOperation(
         txId: Long,
         callingUid: Int,
         data: Parcel,
-    ): TransactionResult =
-        runCatching {
+    ): TransactionResult {
+        var strongBoxSlot: StrongBoxOpSlot? = null
+        try {
+            return runCatching {
                 SystemLogger.debug(
                     "[TX_ID: $txId] createOperation parcel: dataSize=${data.dataSize()} dataAvail=${data.dataAvail()} dataPos=${data.dataPosition()}"
                 )
@@ -347,6 +402,13 @@ class KeyMintSecurityLevelInterceptor(
                 SystemLogger.debug(
                     "[TX_ID: $txId] createOperation descriptor: domain=${keyDescriptor.domain} nspace=${keyDescriptor.nspace} alias=${keyDescriptor.alias}"
                 )
+
+                if (securityLevel == SecurityLevel.STRONGBOX) {
+                    strongBoxSlot = reserveStrongBoxOp(callingUid, txId)
+                    if (strongBoxSlot == null) {
+                        return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
+                    }
+                }
 
                 // Android framework calls createOperation with domain=APP+alias;
                 // keystore2 internally resolves to KEY_ID — but software keys never
@@ -360,7 +422,9 @@ class KeyMintSecurityLevelInterceptor(
                                         SystemLogger.info(
                                             "[TX_ID: $txId] createOperation domain=APP with null alias, forwarding to HAL"
                                         )
-                                        return TransactionResult.ContinueAndSkipPost
+                                        val result = forwardCreateOperation(txId, strongBoxSlot)
+                                        strongBoxSlot = null
+                                        return result
                                     }
                             val key = KeyIdentifier(callingUid, alias)
                             generatedKeys[key]?.let { java.util.AbstractMap.SimpleEntry(key, it) }
@@ -368,7 +432,9 @@ class KeyMintSecurityLevelInterceptor(
                                     SystemLogger.info(
                                         "[TX_ID: $txId] createOperation alias=$alias not in generatedKeys, forwarding to HAL"
                                     )
-                                    return TransactionResult.ContinueAndSkipPost
+                                    val result = forwardCreateOperation(txId, strongBoxSlot)
+                                    strongBoxSlot = null
+                                    return result
                                 }
                         }
                         Domain.KEY_ID -> {
@@ -381,28 +447,25 @@ class KeyMintSecurityLevelInterceptor(
                                         .find { it.value.nspace == nspace }
                             entry
                                 ?: run {
-                                    trackAndEnforceOpLimit(callingUid, txId)?.let {
-                                        return it
-                                    }
                                     SystemLogger.info(
                                         "[TX_ID: $txId] createOperation KeyId(${keyDescriptor.nspace}) NOT FOUND for uid=$callingUid. Forwarding to HAL."
                                     )
-                                    return TransactionResult.ContinueAndSkipPost
+                                    val result = forwardCreateOperation(txId, strongBoxSlot)
+                                    strongBoxSlot = null
+                                    return result
                                 }
                         }
                         else -> {
                             SystemLogger.info(
                                 "[TX_ID: $txId] createOperation domain=${keyDescriptor.domain}, forwarding to HAL"
                             )
-                            return TransactionResult.ContinueAndSkipPost
+                            val result = forwardCreateOperation(txId, strongBoxSlot)
+                            strongBoxSlot = null
+                            return result
                         }
                     }
                 val generatedKeyInfo = resolvedEntry.value
                 val resolvedKeyId = resolvedEntry.key
-
-                trackAndEnforceOpLimit(callingUid, txId)?.let {
-                    return it
-                }
 
                 SystemLogger.info("[TX_ID: $txId] Creating SOFTWARE operation for uid=$callingUid.")
 
@@ -478,6 +541,7 @@ class KeyMintSecurityLevelInterceptor(
                         effectiveParams,
                         opLatency,
                     )
+                strongBoxSlot?.let { slot -> softwareOperation.onFinalizeCallback = slot::release }
 
                 if (keyParams?.usageCountLimit != null) {
                     val limit = keyParams.usageCountLimit
@@ -516,12 +580,17 @@ class KeyMintSecurityLevelInterceptor(
                         parameters = softwareOperation.beginParameters
                     }
 
+                strongBoxSlot = null
                 InterceptorUtils.createTypedObjectReply(response)
             }
             .getOrElse {
                 SystemLogger.error("Error during createOperation for UID $callingUid.", it)
                 InterceptorUtils.createServiceSpecificErrorReply(KEYMINT_UNKNOWN_ERROR)
             }
+        } finally {
+            strongBoxSlot?.release()
+        }
+    }
 
     private fun handleGenerateKey(
         txId: Long,
@@ -1507,7 +1576,6 @@ class KeyMintSecurityLevelInterceptor(
         private const val SECURE_HW_COMMUNICATION_FAILED = -49
         private const val MAX_CONCURRENT_OPS_PER_UID = 15
         private const val STRONGBOX_MAX_CONCURRENT_OPS = 4
-        private const val STRONGBOX_OP_WINDOW_NS = 10_000_000_000L // 10s
 
         private fun isStrongBoxCapable(params: KeyMintAttestation): Boolean =
             when (params.algorithm) {

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -322,17 +322,13 @@ class KeyMintSecurityLevelInterceptor(
 
     private fun trackAndEnforceOpLimit(callingUid: Int, txId: Long): TransactionResult? {
         if (securityLevel != SecurityLevel.STRONGBOX) return null
-        val timestamps = recentOps.computeIfAbsent(callingUid) { ConcurrentLinkedDeque() }
-        val cutoff = System.nanoTime() - STRONGBOX_OP_WINDOW_NS
-        timestamps.removeIf { it < cutoff }
-        val swOps = activeOps[callingUid]?.count { !it.finalized } ?: 0
-        if (timestamps.size + swOps >= STRONGBOX_MAX_CONCURRENT_OPS) {
+        val inFlight = activeOps[callingUid]?.count { !it.finalized } ?: 0
+		if (inFlight >= STRONGBOX_MAX_CONCURRENT_OPS) {
             SystemLogger.info(
-                "[TX_ID: $txId] StrongBox op limit reached for uid=$callingUid (hw=${timestamps.size} sw=$swOps max=$STRONGBOX_MAX_CONCURRENT_OPS)"
+                "[TX_ID: $txId] StrongBox in-flight op limit reached for uid=$callingUid (active=$inFlight max=$STRONGBOX_MAX_CONCURRENT_OPS)"
             )
             return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
         }
-        timestamps.addLast(System.nanoTime())
         return null
     }
 

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/OperationInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/OperationInterceptor.kt
@@ -14,6 +14,7 @@ class OperationInterceptor(
     private val original: IKeystoreOperation,
     private val backdoor: IBinder,
     private val isAead: Boolean,
+    private val onFinalize: (() -> Unit)? = null,
 ) : BinderInterceptor() {
 
     override fun onPreTransact(
@@ -40,7 +41,11 @@ class OperationInterceptor(
         }
 
         if (code == FINISH_TRANSACTION || code == ABORT_TRANSACTION) {
-            KeyMintSecurityLevelInterceptor.removeOperationInterceptor(target, backdoor)
+            try {
+                KeyMintSecurityLevelInterceptor.removeOperationInterceptor(target, backdoor)
+            } finally {
+                onFinalize?.invoke()
+            }
         }
 
         return TransactionResult.ContinueAndSkipPost

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
@@ -16,6 +16,7 @@ import android.system.keystore2.KeyParameters
 import java.security.KeyPair
 import java.security.Signature
 import java.security.SignatureException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
 import javax.crypto.Cipher
 import org.matrix.TEESimulator.attestation.KeyMintAttestation
@@ -334,11 +335,14 @@ class SoftwareOperation(
     private val latencyFloorMs: Long = 0L,
 ) {
     private val primitive: CryptoPrimitive
+    private val finalizeCallbackInvoked = AtomicBoolean(false)
+
     @Volatile
     var finalized = false
         private set
 
     var onFinishCallback: (() -> Unit)? = null
+    var onFinalizeCallback: (() -> Unit)? = null
 
     val beginParameters: KeyParameters?
         get() {
@@ -510,7 +514,7 @@ class SoftwareOperation(
                 val delayMs = latencyFloorMs - elapsedMs
                 if (delayMs > 0) LockSupport.parkNanos(delayMs * 1_000_000)
             }
-            finalized = true
+            finalizeOperation()
             onFinishCallback?.invoke()
             SystemLogger.info("[SoftwareOp TX_ID: $txId] Finished operation successfully.")
             return result
@@ -523,9 +527,16 @@ class SoftwareOperation(
     }
 
     fun abort() {
-        finalized = true
+        finalizeOperation()
         primitive.abort()
         SystemLogger.debug("[SoftwareOp TX_ID: $txId] Operation aborted.")
+    }
+
+    private fun finalizeOperation() {
+        finalized = true
+        if (finalizeCallbackInvoked.compareAndSet(false, true)) {
+            onFinalizeCallback?.invoke()
+        }
     }
 
     private fun mapToServiceSpecificException(e: Exception): ServiceSpecificException =


### PR DESCRIPTION
## Summary

This PR attempts to address #39 by changing the StrongBox operation limiter from a rolling-window rate limit to a true concurrent operation limit.

* Count only active, non-finalized operations for each UID.
* Stop counting recently completed operations within the previous 10-second window.
* Preserve the maximum of four concurrent in-flight StrongBox operations.
* Update the log message to report the active in-flight operation count.

## Background

The previous implementation stored a timestamp for every StrongBox `createOperation` request and counted all requests made within a 10-second window.

As a result, multiple legitimate sequential operations could reach the limit even after the earlier operations had completed. TEESimulator would then return `KEYMINT_TOO_MANY_OPERATIONS` before a real, non-synthetic `Domain.KEY_ID` operation could be handled by the hardware HAL.

This behavior has been reported with 1Password Autofill, `tw.gov.moda.diw`, WhatsApp encrypted backups, and other applications using StrongBox-backed keys.

This change makes the limit reflect concurrent operations rather than operation frequency. Recently completed operations no longer affect subsequent requests.

## Verification

* [x] Verified that `tw.gov.moda.diw` works normally after applying this change.
* [ ] Verify the original 1Password Autofill biometric unlock scenario.
* [ ] Run existing automated tests.

### Additional observation

WhatsApp end-to-end encrypted backups were already working normally in the current test environment before this patch was applied, so WhatsApp could not be used for before-and-after validation.

The reason for this behavior has not been confirmed. It may be related to an application-side fallback or another change in WhatsApp's backup implementation.


## Behavior changes

* Sequential StrongBox operations are no longer rejected merely because four operations occurred within 10 seconds.
* Requests are still rejected when four active, non-finalized StrongBox operations exist for the same UID.
* Non-StrongBox security levels are unaffected.

Refs #39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StrongBox operation-limit enforcement by counting only currently active operations.
  * Removed outdated time-based tracking that could incorrectly affect operation limits.
  * Ensured operation-limit reservations are released reliably when operations fail, are unsupported, forwarded, or encounter errors.
  * Fixed cleanup after successful completion or cancellation so reserved capacity is restored consistently.
  * Prevented duplicate cleanup actions during operation finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->