### PR TITLE
fix(strongbox): enforce in-flight operation limits safely

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
@@ -165,6 +165,27 @@ object InterceptorUtils {
         return exception != null
     }
 
+    /**
+     * Reads the exception a reply parcel carries, if any, without disturbing the caller: the
+     * original data position is always restored. Returns the Throwable that `readException()`
+     * raised (a ServiceSpecificException for EX_SERVICE_SPECIFIC, so callers can inspect its
+     * errorCode) or null when the reply encodes success. Unlike [hasException] this exposes the
+     * exception itself, which callers need to distinguish, e.g., OPERATION_BUSY from a terminal
+     * error.
+     */
+    fun readExceptionOrNull(reply: Parcel): Throwable? {
+        val savedPos = reply.dataPosition()
+        val exception =
+            try {
+                reply.readException()
+                null
+            } catch (t: Throwable) {
+                t
+            }
+        reply.setDataPosition(savedPos)
+        return exception
+    }
+
     fun createServiceSpecificErrorReply(
         errorCode: Int
     ): BinderInterceptor.TransactionResult.OverrideReply = createErrorReply(errorCode)

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -24,7 +24,7 @@ import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
 import org.matrix.TEESimulator.attestation.AttestationBuilder
 import org.matrix.TEESimulator.attestation.AttestationConstants
@@ -61,7 +61,40 @@ class KeyMintSecurityLevelInterceptor(
     )
 
     private val activeOps = ConcurrentHashMap<Int, ConcurrentLinkedDeque<SoftwareOperation>>()
-    private val recentOps = ConcurrentHashMap<Int, ConcurrentLinkedDeque<Long>>()
+    private val strongBoxOps = ConcurrentHashMap<Int, StrongBoxUidState>()
+    private val pendingStrongBoxOps = ConcurrentHashMap<Long, StrongBoxOpSlot>()
+
+    private data class StrongBoxUidState(var inFlight: Int = 0)
+
+    /**
+     * A single reserved StrongBox operation slot for [uid]. At most one release fires per slot,
+     * guarded by [released]. Release coverage differs by path:
+     * - Software operations: wired to [SoftwareOperation.onFinalizeCallback], which fires on
+     *   finish, abort, and any fatal update/finish/updateAad error. This path is complete.
+     * - Forwarded operations: wired to [OperationInterceptor], whose post hook releases after the
+     *   underlying finish/abort returns, or after an update/updateAad that reports an error (AOSP
+     *   deletes the operation on a KM error). This path depends on the client issuing an
+     *   observable transaction.
+     * A client that abandons a forwarded operation with no finish/abort — process death, dropped
+     * binder — leaves no signal, so that slot is not reclaimed. There is deliberately no
+     * time-based reclaim: expiring a slot while the real operation is still live would let a fifth
+     * operation start and break the "at most four" guarantee, and user-interactive StrongBox
+     * operations (e.g. BiometricPrompt) have no bounded lifetime. linkToDeath does not help either:
+     * it only observes death of the process hosting the forwarded binder, not a client dropping its
+     * own reference. If the keystore2 host process dies, this whole interceptor state resets with
+     * it, so a leaked slot cannot outlive that.
+     */
+    private inner class StrongBoxOpSlot(private val uid: Int) {
+        private val released = AtomicBoolean(false)
+
+        fun release() {
+            if (!released.compareAndSet(false, true)) return
+            strongBoxOps.computeIfPresent(uid) { _, state ->
+                state.inFlight--
+                if (state.inFlight <= 0) null else state
+            }
+        }
+    }
 
     override fun onPreTransact(
         txId: Long,
@@ -119,8 +152,12 @@ class KeyMintSecurityLevelInterceptor(
         reply: Parcel?,
         resultCode: Int,
     ): TransactionResult {
-        if (resultCode != 0 || reply == null || InterceptorUtils.hasException(reply))
+        if (resultCode != 0 || reply == null || InterceptorUtils.hasException(reply)) {
+            if (code == CREATE_OPERATION_TRANSACTION) {
+                pendingStrongBoxOps.remove(txId)?.release()
+            }
             return TransactionResult.SkipTransaction
+        }
 
         if (code == IMPORT_KEY_TRANSACTION) {
             logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
@@ -176,50 +213,67 @@ class KeyMintSecurityLevelInterceptor(
                 }
             }
         } else if (code == CREATE_OPERATION_TRANSACTION) {
-            logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
+            val strongBoxSlot = pendingStrongBoxOps.remove(txId)
+            var slotTransferred = false
+            try {
+                logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
 
-            data.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR)
-            val keyDescriptor =
-                data.readTypedObject(KeyDescriptor.CREATOR)
-                    ?: return TransactionResult.SkipTransaction
-            val params =
-                data.createTypedArray(KeyParameter.CREATOR)
-                    ?: return TransactionResult.SkipTransaction
-            val parsedParams = KeyMintAttestation(params)
-            val forced = data.readBoolean()
-            if (forced)
+                data.enforceInterface(IKeystoreSecurityLevel.DESCRIPTOR)
+                val keyDescriptor =
+                    data.readTypedObject(KeyDescriptor.CREATOR)
+                        ?: return TransactionResult.SkipTransaction
+                val params =
+                    data.createTypedArray(KeyParameter.CREATOR)
+                        ?: return TransactionResult.SkipTransaction
+                val parsedParams = KeyMintAttestation(params)
+                val forced = data.readBoolean()
+                if (forced)
+                    SystemLogger.verbose(
+                        "[TX_ID: $txId] Current operation has a very high pruning power."
+                    )
+                val response: CreateOperationResponse =
+                    reply.readTypedObject(CreateOperationResponse.CREATOR)
+                        ?: return TransactionResult.SkipTransaction
                 SystemLogger.verbose(
-                    "[TX_ID: $txId] Current operation has a very high pruning power."
+                    "[TX_ID: $txId] CreateOperationResponse: ${response.iOperation} ${response.operationChallenge}"
                 )
-            val response: CreateOperationResponse =
-                reply.readTypedObject(CreateOperationResponse.CREATOR)
-                    ?: return TransactionResult.SkipTransaction
-            SystemLogger.verbose(
-                "[TX_ID: $txId] CreateOperationResponse: ${response.iOperation} ${response.operationChallenge}"
-            )
 
-            // Intercept the IKeystoreOperation binder
-            response.iOperation?.let { operation ->
-                val operationBinder = operation.asBinder()
-                if (!interceptedOperations.containsKey(operationBinder)) {
-                    SystemLogger.info("Found new IKeystoreOperation. Registering interceptor...")
-                    val backdoor = getBackdoor(target)
-                    if (backdoor != null) {
-                        val isAead = parsedParams.blockMode.firstOrNull() == BlockMode.GCM
-                        val interceptor = OperationInterceptor(operation, backdoor, isAead)
-                        register(
-                            backdoor,
-                            operationBinder,
-                            interceptor,
-                            OperationInterceptor.INTERCEPTED_CODES,
-                        )
-                        interceptedOperations[operationBinder] = interceptor
-                    } else {
-                        SystemLogger.error(
-                            "Failed to get backdoor to register OperationInterceptor."
-                        )
+                // Intercept the IKeystoreOperation binder and hold the reserved StrongBox slot
+                // until the forwarded operation finishes or aborts.
+                response.iOperation?.let { operation ->
+                    val operationBinder = operation.asBinder()
+                    if (!interceptedOperations.containsKey(operationBinder)) {
+                        SystemLogger.info("Found new IKeystoreOperation. Registering interceptor...")
+                        val backdoor = getBackdoor(target)
+                        if (backdoor != null) {
+                            val isAead = parsedParams.blockMode.firstOrNull() == BlockMode.GCM
+                            val interceptor =
+                                OperationInterceptor(
+                                    operation,
+                                    backdoor,
+                                    isAead,
+                                    strongBoxSlot?.let { slot -> slot::release },
+                                )
+                            if (
+                                register(
+                                    backdoor,
+                                    operationBinder,
+                                    interceptor,
+                                    OperationInterceptor.INTERCEPTED_CODES,
+                                )
+                            ) {
+                                interceptedOperations[operationBinder] = interceptor
+                                slotTransferred = strongBoxSlot != null
+                            }
+                        } else {
+                            SystemLogger.error(
+                                "Failed to get backdoor to register OperationInterceptor."
+                            )
+                        }
                     }
                 }
+            } finally {
+                if (!slotTransferred) strongBoxSlot?.release()
             }
         } else if (code == GENERATE_KEY_TRANSACTION) {
             logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
@@ -320,28 +374,55 @@ class KeyMintSecurityLevelInterceptor(
         )
     }
 
-    private fun trackAndEnforceOpLimit(callingUid: Int, txId: Long): TransactionResult? {
-        if (securityLevel != SecurityLevel.STRONGBOX) return null
-        val timestamps = recentOps.computeIfAbsent(callingUid) { ConcurrentLinkedDeque() }
-        val cutoff = System.nanoTime() - STRONGBOX_OP_WINDOW_NS
-        timestamps.removeIf { it < cutoff }
-        val swOps = activeOps[callingUid]?.count { !it.finalized } ?: 0
-        if (timestamps.size + swOps >= STRONGBOX_MAX_CONCURRENT_OPS) {
-            SystemLogger.info(
-                "[TX_ID: $txId] StrongBox op limit reached for uid=$callingUid (hw=${timestamps.size} sw=$swOps max=$STRONGBOX_MAX_CONCURRENT_OPS)"
-            )
-            return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
+    private fun reserveStrongBoxOp(callingUid: Int, txId: Long): StrongBoxOpSlot? {
+        var slot: StrongBoxOpSlot? = null
+        var inFlight = 0
+        strongBoxOps.compute(callingUid) { _, current ->
+            val state = current ?: StrongBoxUidState()
+            if (state.inFlight < STRONGBOX_MAX_CONCURRENT_OPS) {
+                state.inFlight++
+                slot = StrongBoxOpSlot(callingUid)
+            }
+            inFlight = state.inFlight
+            if (state.inFlight <= 0) null else state
         }
-        timestamps.addLast(System.nanoTime())
-        return null
+        if (slot == null) {
+            SystemLogger.info(
+                "[TX_ID: $txId] StrongBox in-flight op limit reached for uid=$callingUid (active=$inFlight max=$STRONGBOX_MAX_CONCURRENT_OPS)"
+            )
+        }
+        return slot
+    }
+
+    /**
+     * Forwards the createOperation to the real HAL, returning [TransactionResult.Continue] so the
+     * CREATE_OPERATION post hook runs and wraps the returned IKeystoreOperation with an
+     * [OperationInterceptor]. That wrapping is required for every security level (it drives the
+     * non-AEAD updateAad vendor gate and, for StrongBox, the slot release), so non-StrongBox levels
+     * must not skip the post hook. For StrongBox this also reserves a slot and parks it in
+     * [pendingStrongBoxOps] keyed by txId, so the post hook can hand it to the interceptor; the slot
+     * is released when that operation finishes or aborts. If no slot is available the request is
+     * rejected with TOO_MANY_OPERATIONS rather than forwarded, so a real StrongBox op is never
+     * started beyond the limit. Non-StrongBox levels have no slot accounting and are forwarded
+     * unconditionally, with no slot handed to the interceptor.
+     */
+    private fun forwardCreateOperation(txId: Long, callingUid: Int): TransactionResult {
+        if (securityLevel != SecurityLevel.STRONGBOX) return TransactionResult.Continue
+        val slot =
+            reserveStrongBoxOp(callingUid, txId)
+                ?: return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
+        pendingStrongBoxOps.put(txId, slot)?.release()
+        return TransactionResult.Continue
     }
 
     private fun handleCreateOperation(
         txId: Long,
         callingUid: Int,
         data: Parcel,
-    ): TransactionResult =
-        runCatching {
+    ): TransactionResult {
+        var strongBoxSlot: StrongBoxOpSlot? = null
+        try {
+            return runCatching {
                 SystemLogger.debug(
                     "[TX_ID: $txId] createOperation parcel: dataSize=${data.dataSize()} dataAvail=${data.dataAvail()} dataPos=${data.dataPosition()}"
                 )
@@ -364,7 +445,7 @@ class KeyMintSecurityLevelInterceptor(
                                         SystemLogger.info(
                                             "[TX_ID: $txId] createOperation domain=APP with null alias, forwarding to HAL"
                                         )
-                                        return TransactionResult.ContinueAndSkipPost
+                                        return forwardCreateOperation(txId, callingUid)
                                     }
                             val key = KeyIdentifier(callingUid, alias)
                             generatedKeys[key]?.let { java.util.AbstractMap.SimpleEntry(key, it) }
@@ -372,7 +453,7 @@ class KeyMintSecurityLevelInterceptor(
                                     SystemLogger.info(
                                         "[TX_ID: $txId] createOperation alias=$alias not in generatedKeys, forwarding to HAL"
                                     )
-                                    return TransactionResult.ContinueAndSkipPost
+                                    return forwardCreateOperation(txId, callingUid)
                                 }
                         }
                         Domain.KEY_ID -> {
@@ -385,28 +466,21 @@ class KeyMintSecurityLevelInterceptor(
                                         .find { it.value.nspace == nspace }
                             entry
                                 ?: run {
-                                    trackAndEnforceOpLimit(callingUid, txId)?.let {
-                                        return it
-                                    }
                                     SystemLogger.info(
                                         "[TX_ID: $txId] createOperation KeyId(${keyDescriptor.nspace}) NOT FOUND for uid=$callingUid. Forwarding to HAL."
                                     )
-                                    return TransactionResult.ContinueAndSkipPost
+                                    return forwardCreateOperation(txId, callingUid)
                                 }
                         }
                         else -> {
                             SystemLogger.info(
                                 "[TX_ID: $txId] createOperation domain=${keyDescriptor.domain}, forwarding to HAL"
                             )
-                            return TransactionResult.ContinueAndSkipPost
+                            return forwardCreateOperation(txId, callingUid)
                         }
                     }
                 val generatedKeyInfo = resolvedEntry.value
                 val resolvedKeyId = resolvedEntry.key
-
-                trackAndEnforceOpLimit(callingUid, txId)?.let {
-                    return it
-                }
 
                 SystemLogger.info("[TX_ID: $txId] Creating SOFTWARE operation for uid=$callingUid.")
 
@@ -507,8 +581,28 @@ class KeyMintSecurityLevelInterceptor(
                     }
                 }
 
+                // Reserve the StrongBox slot only now: the request is valid, resolves to the
+                // software path, passed authorize_create, the SoftwareOperation was constructed
+                // successfully, and the usage-count check (which can still reject with
+                // KEY_NOT_FOUND) has passed. Reserving earlier could count a request that a later
+                // check would reject. When four operations are already in flight the request is
+                // rejected with TOO_MANY_OPERATIONS; a live operation is never aborted to make room,
+                // matching the concurrent-limit contract this PR defines.
+                if (securityLevel == SecurityLevel.STRONGBOX) {
+                    strongBoxSlot = reserveStrongBoxOp(callingUid, txId)
+                    if (strongBoxSlot == null) {
+                        return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
+                    }
+                    strongBoxSlot?.let { slot -> softwareOperation.onFinalizeCallback = slot::release }
+                }
+
+                // For StrongBox the reservation gate above is the sole enforcer of the concurrent
+                // limit; a request that reaches here already holds a slot, so pruneOpsForUid must
+                // only track the operation and drop finalized entries, never abort a live op to
+                // make room. Passing Int.MAX_VALUE disables its LRU eviction for StrongBox while
+                // keeping the deque bookkeeping. Non-StrongBox levels keep their existing LRU cap.
                 val maxOps =
-                    if (securityLevel == SecurityLevel.STRONGBOX) STRONGBOX_MAX_CONCURRENT_OPS
+                    if (securityLevel == SecurityLevel.STRONGBOX) Int.MAX_VALUE
                     else MAX_CONCURRENT_OPS_PER_UID
                 pruneOpsForUid(callingUid, softwareOperation, maxOps)
                 val operationBinder = SoftwareOperationBinder(softwareOperation)
@@ -520,12 +614,22 @@ class KeyMintSecurityLevelInterceptor(
                         parameters = softwareOperation.beginParameters
                     }
 
-                InterceptorUtils.createTypedObjectReply(response)
+                // Build the reply before clearing strongBoxSlot: if it throws, the runCatching
+                // below turns this into an error reply and the operation never reaches the client,
+                // so the finally block must still release the reservation. onFinalizeCallback keeps
+                // the slot alive for the delivered operation.
+                val reply = InterceptorUtils.createTypedObjectReply(response)
+                strongBoxSlot = null
+                reply
             }
             .getOrElse {
                 SystemLogger.error("Error during createOperation for UID $callingUid.", it)
                 InterceptorUtils.createServiceSpecificErrorReply(KEYMINT_UNKNOWN_ERROR)
             }
+        } finally {
+            strongBoxSlot?.release()
+        }
+    }
 
     private fun handleGenerateKey(
         txId: Long,
@@ -1511,7 +1615,6 @@ class KeyMintSecurityLevelInterceptor(
         private const val SECURE_HW_COMMUNICATION_FAILED = -49
         private const val MAX_CONCURRENT_OPS_PER_UID = 15
         private const val STRONGBOX_MAX_CONCURRENT_OPS = 4
-        private const val STRONGBOX_OP_WINDOW_NS = 10_000_000_000L // 10s
 
         private fun isStrongBoxCapable(params: KeyMintAttestation): Boolean =
             when (params.algorithm) {

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/OperationInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/OperationInterceptor.kt
@@ -2,6 +2,7 @@ package org.matrix.TEESimulator.interception.keystore.shim
 
 import android.os.IBinder
 import android.os.Parcel
+import android.os.ServiceSpecificException
 import android.system.keystore2.IKeystoreOperation
 import org.matrix.TEESimulator.interception.core.BinderInterceptor
 import org.matrix.TEESimulator.interception.keystore.InterceptorUtils
@@ -9,11 +10,34 @@ import org.matrix.TEESimulator.interception.keystore.InterceptorUtils
 /**
  * Intercepts calls to an `IKeystoreOperation` service. This is used to log the data manipulation
  * methods of a cryptographic operation.
+ *
+ * For a forwarded StrongBox operation, [onFinalize] releases the reserved slot. It fires from
+ * [onPostTransact] only once the operation has really ended, which is not the same as "the call
+ * returned an error". AOSP Keystore2's with_locked_operation() drops the operation when a KM call
+ * reports an error, but two cases do not end it and must not release the slot:
+ * - OPERATION_BUSY (ResponseCode 19): another thread holds the operation lock, so this call never
+ *   entered the operation and the operation is still alive. finish/abort can also report this.
+ * - Transport failures (resultCode != 0, e.g. the request never reached keystore2): the operation
+ *   may well still be alive, so releasing would undercount it.
+ *
+ * Release therefore fires on: a successful finish/abort, or an update/updateAad that returns a
+ * genuine service error other than OPERATION_BUSY. A successful update/updateAad leaves the
+ * operation running and does nothing.
+ *
+ * Known limitation: a client that abandons the operation with no finish/abort — process death or a
+ * dropped binder reference — produces no observable transaction, so its slot is not reclaimed.
+ * A non-AEAD synthetic updateAad reply is likewise not treated as terminal, since the underlying
+ * HAL operation was never invoked and is still live. Neither a timeout (would reap live
+ * user-interactive operations) nor linkToDeath solves this: linkToDeath only observes death of the
+ * process hosting the forwarded binder, and does not report that another client abandoned its
+ * reference. These are accepted residual cases; if the keystore2 host process itself dies, the
+ * whole interceptor state is reset with it, so a leaked slot cannot outlive that.
  */
 class OperationInterceptor(
     private val original: IKeystoreOperation,
     private val backdoor: IBinder,
     private val isAead: Boolean,
+    private val onFinalize: (() -> Unit)? = null,
 ) : BinderInterceptor() {
 
     override fun onPreTransact(
@@ -26,12 +50,13 @@ class OperationInterceptor(
         data: Parcel,
     ): TransactionResult {
         val methodName = transactionNames[code] ?: "unknown code=$code"
-        logTransaction(txId, methodName, callingUid, callingPid, true)
 
         // Mirror SoftwareOperation's vendor gate: a real-key op must answer non-AEAD updateAad
         // exactly as the forged-key path does. Samsung and Xiaomi-MTK TEEs accept it; rejecting
-        // here while the forged path accepts diverges the two and fingerprints the injection.
+        // here while the forged path accepts diverges the two and fingerprints the injection. The
+        // underlying operation is not called, so this does not end it and the slot is retained.
         if (code == UPDATE_AAD_TRANSACTION && !isAead) {
+            logTransaction(txId, methodName, callingUid, callingPid, true)
             return if (VendorQuirks.nonAeadUpdateAadSucceeds()) {
                 InterceptorUtils.createSuccessReply(writeResultCode = false)
             } else {
@@ -39,14 +64,47 @@ class OperationInterceptor(
             }
         }
 
-        if (code == FINISH_TRANSACTION || code == ABORT_TRANSACTION) {
-            KeyMintSecurityLevelInterceptor.removeOperationInterceptor(target, backdoor)
-        }
+        // finish/abort, update, and AEAD updateAad all need the reply to decide whether the
+        // operation ended, so run the original call and classify in onPostTransact. keystore2
+        // keeps the operation's resources alive until the underlying call returns, so deferring
+        // any slot release to the post hook keeps the in-flight accounting honest.
+        val needsPostHook =
+            code == FINISH_TRANSACTION ||
+                code == ABORT_TRANSACTION ||
+                code == UPDATE_TRANSACTION ||
+                (code == UPDATE_AAD_TRANSACTION && isAead)
+        logTransaction(txId, methodName, callingUid, callingPid, !needsPostHook)
+        if (needsPostHook) return TransactionResult.Continue
 
         return TransactionResult.ContinueAndSkipPost
     }
 
+    override fun onPostTransact(
+        txId: Long,
+        target: IBinder,
+        code: Int,
+        flags: Int,
+        callingUid: Int,
+        callingPid: Int,
+        data: Parcel,
+        reply: Parcel?,
+        resultCode: Int,
+    ): TransactionResult {
+        if (operationEnded(code, resultCode, reply)) {
+            try {
+                KeyMintSecurityLevelInterceptor.removeOperationInterceptor(target, backdoor)
+            } finally {
+                onFinalize?.invoke()
+            }
+        }
+        return TransactionResult.SkipTransaction
+    }
+
     companion object {
+        // ResponseCode.OPERATION_BUSY: the caller tried to advance an operation that another
+        // thread is already advancing. The call never entered the operation, so it stays alive.
+        private const val RESPONSE_OPERATION_BUSY = 19
+
         private val UPDATE_AAD_TRANSACTION =
             InterceptorUtils.getTransactCode(IKeystoreOperation.Stub::class.java, "updateAad")
         private val UPDATE_TRANSACTION =
@@ -57,7 +115,47 @@ class OperationInterceptor(
             InterceptorUtils.getTransactCode(IKeystoreOperation.Stub::class.java, "abort")
 
         val INTERCEPTED_CODES =
-            intArrayOf(UPDATE_AAD_TRANSACTION, FINISH_TRANSACTION, ABORT_TRANSACTION)
+            intArrayOf(
+                UPDATE_AAD_TRANSACTION,
+                UPDATE_TRANSACTION,
+                FINISH_TRANSACTION,
+                ABORT_TRANSACTION,
+            )
+
+        /**
+         * Decides whether the operation ended, given the transaction code, the native transport
+         * [resultCode], and the [reply] parcel. Extracted and internal so it can be unit-tested
+         * without a live binder.
+         */
+        internal fun operationEnded(code: Int, resultCode: Int, reply: Parcel?): Boolean {
+            // A transport-level failure is not a KM operation error; the operation may still be
+            // alive (the request may not even have reached keystore2). Conservatively retain.
+            if (resultCode != 0 || reply == null) return false
+
+            val exception = InterceptorUtils.readExceptionOrNull(reply)
+
+            // OPERATION_BUSY means another thread holds the operation lock; the call never entered
+            // the operation, so it is still alive regardless of which method reported it.
+            if (
+                exception is ServiceSpecificException &&
+                    exception.errorCode == RESPONSE_OPERATION_BUSY
+            ) {
+                return false
+            }
+
+            return when (code) {
+                // A successful finish/abort ends the operation. (An error other than
+                // OPERATION_BUSY also terminates it, and finish/abort never legitimately continue,
+                // so treat any non-busy outcome here as terminal.)
+                FINISH_TRANSACTION,
+                ABORT_TRANSACTION -> true
+                // update / AEAD updateAad end the operation only on a genuine service error
+                // (other than OPERATION_BUSY, handled above); a successful call keeps it running.
+                UPDATE_TRANSACTION,
+                UPDATE_AAD_TRANSACTION -> exception != null
+                else -> false
+            }
+        }
 
         private val transactionNames: Map<Int, String> by lazy {
             IKeystoreOperation.Stub::class

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
@@ -16,6 +16,7 @@ import android.system.keystore2.KeyParameters
 import java.security.KeyPair
 import java.security.Signature
 import java.security.SignatureException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
 import javax.crypto.Cipher
 import org.matrix.TEESimulator.attestation.KeyMintAttestation
@@ -334,11 +335,14 @@ class SoftwareOperation(
     private val latencyFloorMs: Long = 0L,
 ) {
     private val primitive: CryptoPrimitive
+    private val finalizeCallbackInvoked = AtomicBoolean(false)
+
     @Volatile
     var finalized = false
         private set
 
     var onFinishCallback: (() -> Unit)? = null
+    var onFinalizeCallback: (() -> Unit)? = null
 
     val beginParameters: KeyParameters?
         get() {
@@ -469,8 +473,8 @@ class SoftwareOperation(
             "[SoftwareOp TX_ID: $txId] updateAad() ENTRY inputSize=${aadInput?.size ?: 0} primitive=${primitive::class.simpleName}"
         )
         checkActive()
-        checkInputLength(aadInput)
         try {
+            checkInputLength(aadInput)
             primitive.updateAad(aadInput)
             SystemLogger.info(
                 "[SoftwareOp TX_ID: $txId] updateAad() RETURNED_NORMALLY (unexpected for non-AEAD)"
@@ -481,6 +485,8 @@ class SoftwareOperation(
             SystemLogger.info(
                 "[SoftwareOp TX_ID: $txId] updateAad() THREW class=${throwable::class.java.name} code=$code msg=${throwable.message} top=$top"
             )
+            // A failed updateAad ends the operation in AOSP Keystore2; finalize to release the slot.
+            finalizeOperation()
             throw throwable
         }
     }
@@ -488,21 +494,26 @@ class SoftwareOperation(
     fun update(data: ByteArray?): ByteArray? {
         SystemLogger.debug("[SoftwareOp TX_ID: $txId] update() inputSize=${data?.size ?: 0}")
         checkActive()
-        checkInputLength(data)
         try {
+            checkInputLength(data)
             return primitive.update(data)
         } catch (e: ServiceSpecificException) {
+            // AOSP Keystore2 with_locked_operation() removes the operation when the KM call
+            // returns an error, so a failed update ends the operation on the real device too.
+            // Finalize here to release any reserved slot instead of leaking it until reboot.
+            finalizeOperation()
             throw e
         } catch (e: Exception) {
             SystemLogger.error("[SoftwareOp TX_ID: $txId] Failed to update operation.", e)
+            finalizeOperation()
             throw mapToServiceSpecificException(e)
         }
     }
 
     fun finish(data: ByteArray?, signature: ByteArray?): ByteArray? {
         checkActive()
-        checkInputLength(data)
         try {
+            checkInputLength(data)
             val startNs = if (latencyFloorMs > 0) System.nanoTime() else 0L
             val result = primitive.finish(data, signature)
             if (latencyFloorMs > 0) {
@@ -510,22 +521,34 @@ class SoftwareOperation(
                 val delayMs = latencyFloorMs - elapsedMs
                 if (delayMs > 0) LockSupport.parkNanos(delayMs * 1_000_000)
             }
-            finalized = true
+            finalizeOperation()
             onFinishCallback?.invoke()
             SystemLogger.info("[SoftwareOp TX_ID: $txId] Finished operation successfully.")
             return result
         } catch (e: ServiceSpecificException) {
+            // A finish() that reports an error still terminates the operation in AOSP Keystore2,
+            // so finalize on the error path too; onFinishCallback is intentionally not fired since
+            // the operation did not complete successfully.
+            finalizeOperation()
             throw e
         } catch (e: Exception) {
             SystemLogger.error("[SoftwareOp TX_ID: $txId] Failed to finish operation.", e)
+            finalizeOperation()
             throw mapToServiceSpecificException(e)
         }
     }
 
     fun abort() {
-        finalized = true
+        finalizeOperation()
         primitive.abort()
         SystemLogger.debug("[SoftwareOp TX_ID: $txId] Operation aborted.")
+    }
+
+    private fun finalizeOperation() {
+        finalized = true
+        if (finalizeCallbackInvoked.compareAndSet(false, true)) {
+            onFinalizeCallback?.invoke()
+        }
     }
 
     private fun mapToServiceSpecificException(e: Exception): ServiceSpecificException =


### PR DESCRIPTION
## Summary

This PR supersedes #50 with a rebased and review-clean implementation.

It preserves the per-UID StrongBox limit of four active operations while extending the accounting to both software-backed and forwarded HAL operations.

* Reserve operation slots atomically per UID.
* Reject the fifth concurrent request with `TOO_MANY_OPERATIONS`.
* Never prune or abort an existing live StrongBox operation to admit a new one.
* Track forwarded operations until their actual terminal transaction completes.
* Finalize software operations after terminal update, updateAad, or finish errors.
* Preserve reply `Parcel` positions while inspecting service exceptions.

## Why the wider scope is necessary

The original accounting only covered locally created `SoftwareOperation` instances. Operations forwarded to the real StrongBox HAL could therefore bypass the limit, while releasing a slot from `OperationInterceptor.onPreTransact()` could undercount an operation before the underlying finish or abort call had completed.

Addressing both cases requires coordinated changes across four files:

* `KeyMintSecurityLevelInterceptor.kt` owns the atomic per-UID reservation gate and transfers slots to created operations.
* `OperationInterceptor.kt` observes forwarded operation replies and releases slots only after a terminal result.
* `SoftwareOperation.kt` aligns local terminal-error handling with Keystore2 operation lifetime behavior.
* `InterceptorUtils.kt` reads reply exceptions without consuming or repositioning the original `Parcel`.

## Operation lifetime rules

| Transaction result                      | Slot handling |
| --------------------------------------- | ------------- |
| Successful `update` or AEAD `updateAad` | Retain        |
| Successful `finish` or `abort`          | Release       |
| Non-busy KeyMint/service error          | Release       |
| `OPERATION_BUSY`                        | Retain        |
| Transport failure                       | Retain        |
| Missing reply                           | Retain        |
| Non-AEAD synthetic `updateAad`          | Retain        |

`OPERATION_BUSY` is not terminal: it means another thread owns the operation lock and the call did not enter the operation. Transport failures are also retained conservatively because they do not prove that the underlying operation ended.

This behavior follows the operation lifetime handling in [AOSP Keystore2](https://android.googlesource.com/platform/system/security/+/refs/heads/master/keystore2/src/operation.rs).

## Concurrency behavior

For each UID:

1. The first four active StrongBox operations reserve slots successfully.
2. A fifth request is rejected with `TOO_MANY_OPERATIONS`.
3. No existing operation is evicted or aborted.
4. A new request can proceed only after an existing slot receives a confirmed terminal signal.

The reservation gate is the sole StrongBox concurrency enforcer. Existing non-StrongBox LRU behavior remains unchanged.

## Known limitations

A client that abandons an operation without issuing another observable transaction, such as by dying or dropping its binder reference without calling finish or abort, provides no reliable reclamation signal.

No timeout-based cleanup is used because a legitimate user-interactive StrongBox operation may remain active for an unbounded period. Reclaiming it by age could allow a fifth real operation and violate the hard concurrency limit.

A synthetic non-AEAD `updateAad` response also retains the slot because the underlying forwarded HAL operation was not invoked and remains alive.

## Test plan

### Build and static checks

* [x] Run Kotlin formatting checks.
* [x] Compile the Android project with SDK 36 and JDK 21.
* [x] Confirm the rebased branch applies cleanly to the latest upstream branch.

### Operation accounting

* [ ] Confirm four concurrent StrongBox operations are accepted.
* [ ] Confirm the fifth request returns `TOO_MANY_OPERATIONS`.
* [ ] Confirm no existing operation is aborted when the limit is reached.
* [ ] Confirm successful finish and abort calls release their slots.
* [ ] Confirm successful update and updateAad calls retain their slots.
* [ ] Confirm non-busy service errors release their slots.
* [ ] Confirm `OPERATION_BUSY` does not release a slot.
* [ ] Confirm transport failures and missing replies do not release a slot.

### Device regression

* [ ] Test a software-backed StrongBox operation.
* [ ] Test an operation forwarded to the real StrongBox HAL.
* [ ] Test 1Password Autofill.
* [ ] Test `tw.gov.moda.diw`.
* [ ] Verify finish, abort, update, and updateAad behavior on a physical device.

Refs https://github.com/Enginex0/TEESimulator-RS/issues/39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StrongBox operation-limit enforcement with accurate per-app tracking.
  * Ensured operation slots are released after completion, cancellation, failures, or invalid responses.
  * Preserved detailed service errors when processing failed operations.
  * Improved cleanup for failed encryption, decryption, and authentication operations.
  * Prevented operations from being finalized more than once.
  * Improved handling of in-progress updates and transport failures.
  * Improved validation and cleanup when operation inputs are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->