### PR TITLE
fix(strongbox): stop double-counting HAL operations; gate only software ops

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
@@ -165,6 +165,27 @@ object InterceptorUtils {
         return exception != null
     }
 
+    /**
+     * Reads the exception a reply parcel carries, if any, without disturbing the caller: the
+     * original data position is always restored. Returns the Throwable that `readException()`
+     * raised (a ServiceSpecificException for EX_SERVICE_SPECIFIC, so callers can inspect its
+     * errorCode) or null when the reply encodes success. Unlike [hasException] this exposes the
+     * exception itself, which callers need to distinguish, e.g., OPERATION_BUSY from a terminal
+     * error.
+     */
+    fun readExceptionOrNull(reply: Parcel): Throwable? {
+        val savedPos = reply.dataPosition()
+        val exception =
+            try {
+                reply.readException()
+                null
+            } catch (t: Throwable) {
+                t
+            }
+        reply.setDataPosition(savedPos)
+        return exception
+    }
+
     fun createServiceSpecificErrorReply(
         errorCode: Int
     ): BinderInterceptor.TransactionResult.OverrideReply = createErrorReply(errorCode)

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -24,7 +24,7 @@ import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
 import org.matrix.TEESimulator.attestation.AttestationBuilder
 import org.matrix.TEESimulator.attestation.AttestationConstants
@@ -61,7 +61,68 @@ class KeyMintSecurityLevelInterceptor(
     )
 
     private val activeOps = ConcurrentHashMap<Int, ConcurrentLinkedDeque<SoftwareOperation>>()
-    private val recentOps = ConcurrentHashMap<Int, ConcurrentLinkedDeque<Long>>()
+    private val strongBoxOps = ConcurrentHashMap<Int, StrongBoxUidState>()
+
+    /**
+     * Reserved slots for one uid. Every mutation happens inside a [ConcurrentHashMap.compute] block
+     * on [strongBoxOps], so the list needs no lock of its own and the reserve/reclaim decision stays
+     * atomic against concurrent createOperation calls.
+     */
+    private class StrongBoxUidState {
+        val slots = ArrayList<StrongBoxOpSlot>()
+    }
+
+    /**
+     * A single reserved StrongBox operation slot for [uid]. At most one release fires per slot,
+     * guarded by [released].
+     *
+     * Only software-simulated StrongBox operations reserve a slot. Operations forwarded to the real
+     * StrongBox HAL are not gated here: the hardware enforces its own concurrent-operation limit and
+     * answers TOO_MANY_OPERATIONS itself, so a module-side counter for them is redundant. It was also
+     * the cause of #49 — a forwarded finish that completed on hardware never decremented the counter,
+     * which climbed to four and then rejected every StrongBox operation on the device, including apps
+     * not listed in target.txt, because the gate lives at the keystore2 hook level.
+     *
+     * A slot is released only once its operation has finalized. The primary path is
+     * [SoftwareOperation.onFinalizeCallback], which fires on finish, abort, and any fatal
+     * update/finish/updateAad error; [reserveStrongBoxOp] also sweeps finalized slots as a
+     * belt-and-suspenders. There is deliberately no time-based reclaim: dropping the accounting for
+     * a still-live operation would let its SoftwareOperation linger in [activeOps] (whose StrongBox
+     * cap is disabled) while a replacement is admitted, so abandoned operations could accumulate
+     * without bound. Keeping the slot until finalize instead caps live-but-unfinished operations at
+     * [STRONGBOX_MAX_CONCURRENT_OPS] per uid. The trade-off is that an operation abandoned with no
+     * terminal transaction (process death, a dropped binder) holds its slot until keystore2
+     * restarts; four such abandonments wedge that uid's software StrongBox path, which is bounded
+     * and far less severe than an unbounded keystore2 memory leak.
+     */
+    private inner class StrongBoxOpSlot(private val uid: Int) {
+        private val released = AtomicBoolean(false)
+
+        /** The simulated operation holding this slot. */
+        @Volatile var operation: SoftwareOperation? = null
+
+        /** Claims the sole right to account for this slot's release. Idempotent via the CAS. */
+        fun markReleased(): Boolean = released.compareAndSet(false, true)
+
+        /**
+         * Drops this slot's accounting entry. The claim and the list removal happen inside one
+         * [ConcurrentHashMap.computeIfPresent] so they are atomic against a concurrent
+         * [reserveStrongBoxOp] on the same uid: either this removal is observed whole, or the reserve
+         * sweep claims and removes the slot itself. Splitting the two (claim, then remove) would let
+         * a reserve see a finalized-but-not-yet-removed slot it can no longer claim, leaving it in
+         * the list and spuriously rejecting the next request as TOO_MANY_OPERATIONS. [release] is
+         * never called from inside a compute block, so re-entering the map here is safe.
+         */
+        fun release() {
+            strongBoxOps.computeIfPresent(uid) { _, state ->
+                if (markReleased()) state.slots.remove(this)
+                if (state.slots.isEmpty()) null else state
+            }
+        }
+
+        /** Reclaimable only once its operation has finalized; an unfinished operation is kept. */
+        fun isReclaimable(): Boolean = operation?.finalized == true
+    }
 
     override fun onPreTransact(
         txId: Long,
@@ -81,7 +142,7 @@ class KeyMintSecurityLevelInterceptor(
             CREATE_OPERATION_TRANSACTION -> {
                 logTransaction(txId, transactionNames[code]!!, callingUid, callingPid)
 
-                return handleCreateOperation(txId, callingUid, data)
+                return handleCreateOperation(txId, callingUid, callingPid, data)
             }
             IMPORT_KEY_TRANSACTION -> {
                 logTransaction(txId, transactionNames[code]!!, callingUid, callingPid)
@@ -119,8 +180,9 @@ class KeyMintSecurityLevelInterceptor(
         reply: Parcel?,
         resultCode: Int,
     ): TransactionResult {
-        if (resultCode != 0 || reply == null || InterceptorUtils.hasException(reply))
+        if (resultCode != 0 || reply == null || InterceptorUtils.hasException(reply)) {
             return TransactionResult.SkipTransaction
+        }
 
         if (code == IMPORT_KEY_TRANSACTION) {
             logTransaction(txId, "post-${transactionNames[code]!!}", callingUid, callingPid)
@@ -198,22 +260,26 @@ class KeyMintSecurityLevelInterceptor(
                 "[TX_ID: $txId] CreateOperationResponse: ${response.iOperation} ${response.operationChallenge}"
             )
 
-            // Intercept the IKeystoreOperation binder
+            // Wrap the forwarded IKeystoreOperation so the non-AEAD updateAad vendor gate applies.
+            // Forwarded StrongBox operations are limited by the real HAL, so no slot is tracked here.
             response.iOperation?.let { operation ->
                 val operationBinder = operation.asBinder()
                 if (!interceptedOperations.containsKey(operationBinder)) {
-                    SystemLogger.info("Found new IKeystoreOperation. Registering interceptor...")
+                    SystemLogger.trace { "Found new IKeystoreOperation. Registering interceptor..." }
                     val backdoor = getBackdoor(target)
                     if (backdoor != null) {
                         val isAead = parsedParams.blockMode.firstOrNull() == BlockMode.GCM
                         val interceptor = OperationInterceptor(operation, backdoor, isAead)
-                        register(
-                            backdoor,
-                            operationBinder,
-                            interceptor,
-                            OperationInterceptor.INTERCEPTED_CODES,
-                        )
-                        interceptedOperations[operationBinder] = interceptor
+                        if (
+                            register(
+                                backdoor,
+                                operationBinder,
+                                interceptor,
+                                OperationInterceptor.INTERCEPTED_CODES,
+                            )
+                        ) {
+                            interceptedOperations[operationBinder] = interceptor
+                        }
                     } else {
                         SystemLogger.error(
                             "Failed to get backdoor to register OperationInterceptor."
@@ -320,28 +386,91 @@ class KeyMintSecurityLevelInterceptor(
         )
     }
 
-    private fun trackAndEnforceOpLimit(callingUid: Int, txId: Long): TransactionResult? {
-        if (securityLevel != SecurityLevel.STRONGBOX) return null
-        val timestamps = recentOps.computeIfAbsent(callingUid) { ConcurrentLinkedDeque() }
-        val cutoff = System.nanoTime() - STRONGBOX_OP_WINDOW_NS
-        timestamps.removeIf { it < cutoff }
-        val swOps = activeOps[callingUid]?.count { !it.finalized } ?: 0
-        if (timestamps.size + swOps >= STRONGBOX_MAX_CONCURRENT_OPS) {
-            SystemLogger.info(
-                "[TX_ID: $txId] StrongBox op limit reached for uid=$callingUid (hw=${timestamps.size} sw=$swOps max=$STRONGBOX_MAX_CONCURRENT_OPS)"
-            )
-            return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
+    /**
+     * Reserves one of the [STRONGBOX_MAX_CONCURRENT_OPS] in-flight slots for [callingUid], or
+     * returns null so the caller rejects with TOO_MANY_OPERATIONS. Only the software-simulated path
+     * calls this; forwarded operations are limited by the real HAL and are not counted here.
+     *
+     * Before deciding a uid is full, the sweep reclaims slots whose SoftwareOperation has already
+     * finalized. This is a belt-and-suspenders complement to [SoftwareOperation.onFinalizeCallback]
+     * (the normal, immediate release path) and closes the small window where a finish and a new
+     * create interleave. Reclaiming drops the accounting entry only; it never aborts an operation, so
+     * it can never drop a live one. Slots for unfinished operations are kept, which caps live-but-
+     * unfinished operations at [STRONGBOX_MAX_CONCURRENT_OPS] per uid and keeps [activeOps] bounded;
+     * the cost is that an operation abandoned with no terminal transaction holds its slot until
+     * keystore2 restarts.
+     */
+    private fun reserveStrongBoxOp(callingUid: Int, txId: Long): StrongBoxOpSlot? {
+        var slot: StrongBoxOpSlot? = null
+        var reclaimedCount = 0
+        var inFlight = 0
+
+        strongBoxOps.compute(callingUid) { _, current ->
+            val state = current ?: StrongBoxUidState()
+
+            val iterator = state.slots.iterator()
+            while (iterator.hasNext()) {
+                val existing = iterator.next()
+                if (existing.isReclaimable() && existing.markReleased()) {
+                    iterator.remove()
+                    reclaimedCount++
+                }
+            }
+
+            if (state.slots.size < STRONGBOX_MAX_CONCURRENT_OPS) {
+                slot = StrongBoxOpSlot(callingUid).also { state.slots.add(it) }
+            }
+            inFlight = state.slots.size
+            if (state.slots.isEmpty()) null else state
         }
-        timestamps.addLast(System.nanoTime())
-        return null
+
+        if (reclaimedCount > 0) {
+            SystemLogger.info(
+                "[TX_ID: $txId] Reclaimed StrongBox slots for uid=$callingUid (reclaimed=$reclaimedCount active=$inFlight)"
+            )
+        }
+        if (slot == null) {
+            SystemLogger.info(
+                "[TX_ID: $txId] StrongBox in-flight op limit reached for uid=$callingUid (active=$inFlight max=$STRONGBOX_MAX_CONCURRENT_OPS)"
+            )
+        }
+        return slot
+    }
+
+    /**
+     * Forwards the createOperation to the real HAL, returning [TransactionResult.Continue] so the
+     * CREATE_OPERATION post hook runs and wraps the returned IKeystoreOperation with an
+     * [OperationInterceptor]. That wrapping is required for every security level (it drives the
+     * non-AEAD updateAad vendor gate), so no level may skip the post hook.
+     *
+     * Forwarded StrongBox operations are intentionally not gated here. They run on the real StrongBox
+     * HAL, which enforces its own concurrent-operation limit and answers TOO_MANY_OPERATIONS itself,
+     * so a module-side counter for them was redundant — and it was the cause of #49: a forwarded
+     * finish that completed on hardware never decremented the counter, which climbed to four and then
+     * rejected every StrongBox operation on the device, including apps not in target.txt. Only
+     * software-simulated StrongBox operations, which have no hardware enforcer, are gated (in
+     * [handleCreateOperation]).
+     */
+    private fun forwardCreateOperation(
+        txId: Long,
+        callingUid: Int,
+        callingPid: Int,
+    ): TransactionResult {
+        SystemLogger.trace {
+            "[TX_ID: $txId] Forwarding createOperation to HAL for uid=$callingUid pid=$callingPid (no module gate)"
+        }
+        return TransactionResult.Continue
     }
 
     private fun handleCreateOperation(
         txId: Long,
         callingUid: Int,
+        callingPid: Int,
         data: Parcel,
-    ): TransactionResult =
-        runCatching {
+    ): TransactionResult {
+        var strongBoxSlot: StrongBoxOpSlot? = null
+        try {
+            return runCatching {
                 SystemLogger.debug(
                     "[TX_ID: $txId] createOperation parcel: dataSize=${data.dataSize()} dataAvail=${data.dataAvail()} dataPos=${data.dataPosition()}"
                 )
@@ -364,7 +493,7 @@ class KeyMintSecurityLevelInterceptor(
                                         SystemLogger.info(
                                             "[TX_ID: $txId] createOperation domain=APP with null alias, forwarding to HAL"
                                         )
-                                        return TransactionResult.ContinueAndSkipPost
+                                        return forwardCreateOperation(txId, callingUid, callingPid)
                                     }
                             val key = KeyIdentifier(callingUid, alias)
                             generatedKeys[key]?.let { java.util.AbstractMap.SimpleEntry(key, it) }
@@ -372,7 +501,7 @@ class KeyMintSecurityLevelInterceptor(
                                     SystemLogger.info(
                                         "[TX_ID: $txId] createOperation alias=$alias not in generatedKeys, forwarding to HAL"
                                     )
-                                    return TransactionResult.ContinueAndSkipPost
+                                    return forwardCreateOperation(txId, callingUid, callingPid)
                                 }
                         }
                         Domain.KEY_ID -> {
@@ -385,28 +514,21 @@ class KeyMintSecurityLevelInterceptor(
                                         .find { it.value.nspace == nspace }
                             entry
                                 ?: run {
-                                    trackAndEnforceOpLimit(callingUid, txId)?.let {
-                                        return it
-                                    }
                                     SystemLogger.info(
                                         "[TX_ID: $txId] createOperation KeyId(${keyDescriptor.nspace}) NOT FOUND for uid=$callingUid. Forwarding to HAL."
                                     )
-                                    return TransactionResult.ContinueAndSkipPost
+                                    return forwardCreateOperation(txId, callingUid, callingPid)
                                 }
                         }
                         else -> {
                             SystemLogger.info(
                                 "[TX_ID: $txId] createOperation domain=${keyDescriptor.domain}, forwarding to HAL"
                             )
-                            return TransactionResult.ContinueAndSkipPost
+                            return forwardCreateOperation(txId, callingUid, callingPid)
                         }
                     }
                 val generatedKeyInfo = resolvedEntry.value
                 val resolvedKeyId = resolvedEntry.key
-
-                trackAndEnforceOpLimit(callingUid, txId)?.let {
-                    return it
-                }
 
                 SystemLogger.info("[TX_ID: $txId] Creating SOFTWARE operation for uid=$callingUid.")
 
@@ -507,10 +629,33 @@ class KeyMintSecurityLevelInterceptor(
                     }
                 }
 
+                // Reserve the StrongBox slot only now: the request is valid, resolves to the
+                // software path, passed authorize_create, the SoftwareOperation was constructed
+                // successfully, and the usage-count check (which can still reject with
+                // KEY_NOT_FOUND) has passed. Reserving earlier could count a request that a later
+                // check would reject. When four operations are already in flight the request is
+                // rejected with TOO_MANY_OPERATIONS; a live operation is never aborted to make room,
+                // matching the concurrent-limit contract this PR defines.
+                if (securityLevel == SecurityLevel.STRONGBOX) {
+                    val reserved =
+                        reserveStrongBoxOp(callingUid, txId)
+                            ?: return InterceptorUtils.createErrorReply(KEYMINT_TOO_MANY_OPERATIONS)
+                    // Tag the slot with its software operation so the reserve gate can drop the
+                    // accounting entry once it finalizes. The operation is never aborted to make
+                    // room; a fifth request is rejected instead.
+                    reserved.operation = softwareOperation
+                    softwareOperation.onFinalizeCallback = reserved::release
+                    strongBoxSlot = reserved
+                }
+
+                // For StrongBox the reservation gate above is the sole enforcer of the concurrent
+                // limit; a request that reaches here already holds a slot, so pruneOpsForUid must
+                // only track the operation and drop finalized entries, never abort a live op to
+                // make room. Passing Int.MAX_VALUE disables its LRU eviction for StrongBox while
+                // keeping the deque bookkeeping. Non-StrongBox levels keep their existing LRU cap.
                 val maxOps =
-                    if (securityLevel == SecurityLevel.STRONGBOX) STRONGBOX_MAX_CONCURRENT_OPS
+                    if (securityLevel == SecurityLevel.STRONGBOX) Int.MAX_VALUE
                     else MAX_CONCURRENT_OPS_PER_UID
-                pruneOpsForUid(callingUid, softwareOperation, maxOps)
                 val operationBinder = SoftwareOperationBinder(softwareOperation)
 
                 val response =
@@ -520,12 +665,25 @@ class KeyMintSecurityLevelInterceptor(
                         parameters = softwareOperation.beginParameters
                     }
 
-                InterceptorUtils.createTypedObjectReply(response)
+                // Track the operation and clear strongBoxSlot only after the reply is built.
+                // beginParameters and createTypedObjectReply can throw; if they do, runCatching
+                // below turns it into an error reply, the operation never reaches the client, and
+                // the finally releases the reservation. Adding to activeOps only now means such a
+                // failed request leaves no un-finalized operation lingering in the deque (which,
+                // with the StrongBox cap disabled, would never be evicted).
+                val reply = InterceptorUtils.createTypedObjectReply(response)
+                pruneOpsForUid(callingUid, softwareOperation, maxOps)
+                strongBoxSlot = null
+                reply
             }
             .getOrElse {
                 SystemLogger.error("Error during createOperation for UID $callingUid.", it)
                 InterceptorUtils.createServiceSpecificErrorReply(KEYMINT_UNKNOWN_ERROR)
             }
+        } finally {
+            strongBoxSlot?.release()
+        }
+    }
 
     private fun handleGenerateKey(
         txId: Long,
@@ -1511,7 +1669,6 @@ class KeyMintSecurityLevelInterceptor(
         private const val SECURE_HW_COMMUNICATION_FAILED = -49
         private const val MAX_CONCURRENT_OPS_PER_UID = 15
         private const val STRONGBOX_MAX_CONCURRENT_OPS = 4
-        private const val STRONGBOX_OP_WINDOW_NS = 10_000_000_000L // 10s
 
         private fun isStrongBoxCapable(params: KeyMintAttestation): Boolean =
             when (params.algorithm) {

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/OperationInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/OperationInterceptor.kt
@@ -2,13 +2,32 @@ package org.matrix.TEESimulator.interception.keystore.shim
 
 import android.os.IBinder
 import android.os.Parcel
+import android.os.ServiceSpecificException
 import android.system.keystore2.IKeystoreOperation
 import org.matrix.TEESimulator.interception.core.BinderInterceptor
 import org.matrix.TEESimulator.interception.keystore.InterceptorUtils
 
 /**
- * Intercepts calls to an `IKeystoreOperation` service. This is used to log the data manipulation
- * methods of a cryptographic operation.
+ * Intercepts calls to an `IKeystoreOperation` service.
+ *
+ * Two jobs:
+ * - Non-AEAD `updateAad` vendor gate: a real-key operation must answer a non-AEAD `updateAad`
+ *   exactly as the forged-key path does. Samsung and Xiaomi-MTK TEEs accept it; rejecting here while
+ *   the forged path accepts would diverge the two and fingerprint the injection. The underlying
+ *   operation is never invoked for this synthetic reply.
+ * - Self-unregistration: `update`, AEAD `updateAad`, `finish`, and `abort` run against the real
+ *   operation and are classified in [onPostTransact] by [operationEnded]. The interceptor removes
+ *   itself only once the operation has truly ended. This is deferred to the post hook (rather than
+ *   [onPreTransact]) because the reply is needed to tell a terminal outcome from one that is not:
+ *   - OPERATION_BUSY (ResponseCode 19): another thread holds the operation lock, so this call never
+ *     entered the operation and it is still alive; finish/abort can also report this.
+ *   - Transport failures (resultCode != 0, e.g. the request never reached keystore2): the operation
+ *     may still be alive.
+ *   Unregistering only on a confirmed terminal result avoids dropping interception of a still-live
+ *   operation (for example a `finish` that returns OPERATION_BUSY).
+ *
+ * This interceptor tracks no in-flight accounting: StrongBox concurrency for forwarded operations is
+ * enforced by the real HAL, not by the module.
  */
 class OperationInterceptor(
     private val original: IKeystoreOperation,
@@ -26,12 +45,14 @@ class OperationInterceptor(
         data: Parcel,
     ): TransactionResult {
         val methodName = transactionNames[code] ?: "unknown code=$code"
-        logTransaction(txId, methodName, callingUid, callingPid, true)
 
         // Mirror SoftwareOperation's vendor gate: a real-key op must answer non-AEAD updateAad
         // exactly as the forged-key path does. Samsung and Xiaomi-MTK TEEs accept it; rejecting
-        // here while the forged path accepts diverges the two and fingerprints the injection.
+        // here while the forged path accepts diverges the two and fingerprints the injection. The
+        // underlying operation is not called, so this does not end it.
         if (code == UPDATE_AAD_TRANSACTION && !isAead) {
+            // This path overrides the reply, so it is an interception, not an observation.
+            logTransaction(txId, methodName, callingUid, callingPid, false)
             return if (VendorQuirks.nonAeadUpdateAadSucceeds()) {
                 InterceptorUtils.createSuccessReply(writeResultCode = false)
             } else {
@@ -39,14 +60,43 @@ class OperationInterceptor(
             }
         }
 
-        if (code == FINISH_TRANSACTION || code == ABORT_TRANSACTION) {
-            KeyMintSecurityLevelInterceptor.removeOperationInterceptor(target, backdoor)
-        }
+        // finish/abort, update, and AEAD updateAad all need the reply to decide whether the
+        // operation ended, so run the original call and classify in onPostTransact. keystore2
+        // keeps the operation's resources alive until the underlying call returns, so deferring
+        // the unregister decision to the post hook keeps it honest.
+        val needsPostHook =
+            code == FINISH_TRANSACTION ||
+                code == ABORT_TRANSACTION ||
+                code == UPDATE_TRANSACTION ||
+                (code == UPDATE_AAD_TRANSACTION && isAead)
+        logTransaction(txId, methodName, callingUid, callingPid, !needsPostHook)
+        if (needsPostHook) return TransactionResult.Continue
 
         return TransactionResult.ContinueAndSkipPost
     }
 
+    override fun onPostTransact(
+        txId: Long,
+        target: IBinder,
+        code: Int,
+        flags: Int,
+        callingUid: Int,
+        callingPid: Int,
+        data: Parcel,
+        reply: Parcel?,
+        resultCode: Int,
+    ): TransactionResult {
+        if (operationEnded(code, resultCode, reply)) {
+            KeyMintSecurityLevelInterceptor.removeOperationInterceptor(target, backdoor)
+        }
+        return TransactionResult.SkipTransaction
+    }
+
     companion object {
+        // ResponseCode.OPERATION_BUSY: the caller tried to advance an operation that another
+        // thread is already advancing. The call never entered the operation, so it stays alive.
+        private const val RESPONSE_OPERATION_BUSY = 19
+
         private val UPDATE_AAD_TRANSACTION =
             InterceptorUtils.getTransactCode(IKeystoreOperation.Stub::class.java, "updateAad")
         private val UPDATE_TRANSACTION =
@@ -57,7 +107,47 @@ class OperationInterceptor(
             InterceptorUtils.getTransactCode(IKeystoreOperation.Stub::class.java, "abort")
 
         val INTERCEPTED_CODES =
-            intArrayOf(UPDATE_AAD_TRANSACTION, FINISH_TRANSACTION, ABORT_TRANSACTION)
+            intArrayOf(
+                UPDATE_AAD_TRANSACTION,
+                UPDATE_TRANSACTION,
+                FINISH_TRANSACTION,
+                ABORT_TRANSACTION,
+            )
+
+        /**
+         * Decides whether the operation ended, given the transaction code, the native transport
+         * [resultCode], and the [reply] parcel. Extracted and internal so it can be unit-tested
+         * without a live binder.
+         */
+        internal fun operationEnded(code: Int, resultCode: Int, reply: Parcel?): Boolean {
+            // A transport-level failure is not a KM operation error; the operation may still be
+            // alive (the request may not even have reached keystore2). Conservatively retain.
+            if (resultCode != 0 || reply == null) return false
+
+            val exception = InterceptorUtils.readExceptionOrNull(reply)
+
+            // OPERATION_BUSY means another thread holds the operation lock; the call never entered
+            // the operation, so it is still alive regardless of which method reported it.
+            if (
+                exception is ServiceSpecificException &&
+                    exception.errorCode == RESPONSE_OPERATION_BUSY
+            ) {
+                return false
+            }
+
+            return when (code) {
+                // A successful finish/abort ends the operation. (An error other than
+                // OPERATION_BUSY also terminates it, and finish/abort never legitimately continue,
+                // so treat any non-busy outcome here as terminal.)
+                FINISH_TRANSACTION,
+                ABORT_TRANSACTION -> true
+                // update / AEAD updateAad end the operation only on a genuine service error
+                // (other than OPERATION_BUSY, handled above); a successful call keeps it running.
+                UPDATE_TRANSACTION,
+                UPDATE_AAD_TRANSACTION -> exception != null
+                else -> false
+            }
+        }
 
         private val transactionNames: Map<Int, String> by lazy {
             IKeystoreOperation.Stub::class

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
@@ -16,6 +16,7 @@ import android.system.keystore2.KeyParameters
 import java.security.KeyPair
 import java.security.Signature
 import java.security.SignatureException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
 import javax.crypto.Cipher
 import org.matrix.TEESimulator.attestation.KeyMintAttestation
@@ -334,11 +335,14 @@ class SoftwareOperation(
     private val latencyFloorMs: Long = 0L,
 ) {
     private val primitive: CryptoPrimitive
+    private val finalizeCallbackInvoked = AtomicBoolean(false)
+
     @Volatile
     var finalized = false
         private set
 
     var onFinishCallback: (() -> Unit)? = null
+    var onFinalizeCallback: (() -> Unit)? = null
 
     val beginParameters: KeyParameters?
         get() {
@@ -469,8 +473,8 @@ class SoftwareOperation(
             "[SoftwareOp TX_ID: $txId] updateAad() ENTRY inputSize=${aadInput?.size ?: 0} primitive=${primitive::class.simpleName}"
         )
         checkActive()
-        checkInputLength(aadInput)
         try {
+            checkInputLength(aadInput)
             primitive.updateAad(aadInput)
             SystemLogger.info(
                 "[SoftwareOp TX_ID: $txId] updateAad() RETURNED_NORMALLY (unexpected for non-AEAD)"
@@ -481,6 +485,8 @@ class SoftwareOperation(
             SystemLogger.info(
                 "[SoftwareOp TX_ID: $txId] updateAad() THREW class=${throwable::class.java.name} code=$code msg=${throwable.message} top=$top"
             )
+            // A failed updateAad ends the operation in AOSP Keystore2; finalize to release the slot.
+            finalizeOperation()
             throw throwable
         }
     }
@@ -488,21 +494,26 @@ class SoftwareOperation(
     fun update(data: ByteArray?): ByteArray? {
         SystemLogger.debug("[SoftwareOp TX_ID: $txId] update() inputSize=${data?.size ?: 0}")
         checkActive()
-        checkInputLength(data)
         try {
+            checkInputLength(data)
             return primitive.update(data)
         } catch (e: ServiceSpecificException) {
+            // AOSP Keystore2 with_locked_operation() removes the operation when the KM call
+            // returns an error, so a failed update ends the operation on the real device too.
+            // Finalize here to release any reserved slot instead of leaking it until reboot.
+            finalizeOperation()
             throw e
         } catch (e: Exception) {
             SystemLogger.error("[SoftwareOp TX_ID: $txId] Failed to update operation.", e)
+            finalizeOperation()
             throw mapToServiceSpecificException(e)
         }
     }
 
     fun finish(data: ByteArray?, signature: ByteArray?): ByteArray? {
         checkActive()
-        checkInputLength(data)
         try {
+            checkInputLength(data)
             val startNs = if (latencyFloorMs > 0) System.nanoTime() else 0L
             val result = primitive.finish(data, signature)
             if (latencyFloorMs > 0) {
@@ -510,22 +521,34 @@ class SoftwareOperation(
                 val delayMs = latencyFloorMs - elapsedMs
                 if (delayMs > 0) LockSupport.parkNanos(delayMs * 1_000_000)
             }
-            finalized = true
+            finalizeOperation()
             onFinishCallback?.invoke()
             SystemLogger.info("[SoftwareOp TX_ID: $txId] Finished operation successfully.")
             return result
         } catch (e: ServiceSpecificException) {
+            // A finish() that reports an error still terminates the operation in AOSP Keystore2,
+            // so finalize on the error path too; onFinishCallback is intentionally not fired since
+            // the operation did not complete successfully.
+            finalizeOperation()
             throw e
         } catch (e: Exception) {
             SystemLogger.error("[SoftwareOp TX_ID: $txId] Failed to finish operation.", e)
+            finalizeOperation()
             throw mapToServiceSpecificException(e)
         }
     }
 
     fun abort() {
-        finalized = true
+        finalizeOperation()
         primitive.abort()
         SystemLogger.debug("[SoftwareOp TX_ID: $txId] Operation aborted.")
+    }
+
+    private fun finalizeOperation() {
+        finalized = true
+        if (finalizeCallbackInvoked.compareAndSet(false, true)) {
+            onFinalizeCallback?.invoke()
+        }
     }
 
     private fun mapToServiceSpecificException(e: Exception): ServiceSpecificException =


### PR DESCRIPTION
# Body

## Summary

Fixes #49. Refs #39.

#49 reported that on StrongBox devices (Snapdragon 8 Elite, NXP secure element,
Android 16) every StrongBox app breaks after its second launch with
`KeyStoreException -29 (TOO_MANY_OPERATIONS)`. The cause: TEESimulator forwards a
StrongBox `createOperation` to the real HAL, the operation `finish` completes
successfully on hardware, but the module's per-UID StrongBox counter is never
decremented. It climbs to four and then rejects every StrongBox operation on the
device — including apps not in `target.txt`, because the gate lives at the
keystore2 hook level, not per target.

The real fix is the one the reporter suggested: do not re-count operations that
are forwarded to the real HAL. The hardware already enforces its own
concurrent-operation limit and answers `TOO_MANY_OPERATIONS` itself, so the
module's counter for forwarded operations was pure downside — it could leak and
wedge the whole device. This PR keeps the simulated four-operation limit (#39)
only for software-simulated StrongBox operations, which have no hardware
enforcer.

## What changed

- **Forwarded StrongBox operations are no longer gated by the module.** They run
  on the real StrongBox HAL, which enforces the concurrency limit and prunes
  abandoned operations. `forwardCreateOperation` now simply forwards; no slot is
  reserved, parked, or transferred. This removes the #49 leak entirely and also
  fixes its device-wide, non-target blast radius, since forwarded operations from
  any UID are no longer counted.

- **Software-simulated StrongBox operations keep the four-slot per-UID limit.**
  Per-UID state is a list of reserved slots. Slots release on finalize —
  `SoftwareOperation.onFinalizeCallback` fires on finish, abort, and any fatal
  update/finish/updateAad error — and `reserveStrongBoxOp` additionally sweeps
  finalized slots before declaring a UID full, so a finish racing a new create is
  not falsely rejected. The claim and the list removal happen inside one
  `computeIfPresent`, so release and the reserve sweep are atomic against each
  other. Slots for unfinished operations are kept, which caps live-but-unfinished
  operations at four per UID and keeps `activeOps` bounded; there is no time-based
  reclaim (it would drop accounting for a live operation and let `activeOps` grow
  without bound). The cost is that an operation abandoned with no terminal
  transaction holds its slot until keystore2 restarts.

- **Removed the process-liveness reclaim tier.** It probed `/proc/$pid` to decide
  whether the owning client was still alive. From the keystore2 context under
  Android's `hidepid=2`, another UID's `/proc/$pid` is not visible, so a live app
  reads as dead and its slot is reclaimed prematurely — which silently stops the
  limit from being enforced at all. `hidepid=2` makes "alive but hidden"
  indistinguishable from "gone", so this cannot be made reliable and is dropped.

- **Removed the live-operation eviction tier.** It aborted the oldest live
  software operation to admit a new one, which contradicts the stated contract
  ("a live operation is never aborted to make room"). A fifth request is now
  rejected with `TOO_MANY_OPERATIONS` instead, and no live operation is touched.

- **Reduced per-operation log noise.** The interceptor-registration line dropped
  from `info` to `trace`. (The remaining "Interceptor registered/unregistered for
  binder ... with N filtered codes" lines come from the core `BinderInterceptor`
  register/unregister path; lowering those to `trace` there removes the rest.)

## Why this is safe

The four-operation guarantee #39 cares about is a hardware property. For forwarded
operations it is enforced by the hardware itself. For software operations it is
enforced here, and reclaiming an abandoned software slot never aborts a live
operation and never starts a fifth real StrongBox operation, because forwarded
operations are not counted here at all. There is no `/proc` dependency and no
self-contradiction.

## Notes

- `SoftwareOperation` (onFinalizeCallback / finalize on terminal error) is
  required and unchanged. `OperationInterceptor` still classifies terminal
  transactions to unregister itself; its optional slot callback is simply never
  supplied now, so forwarded operations carry no module-side accounting.

## Test plan

- [ ] On a StrongBox device, a react-native-keychain app (e.g. PagoPA IO,
      RelaxBanking, MyCartaBCC) survives repeated launches and keychain decrypts
      with no accumulating `TOO_MANY_OPERATIONS`.
- [ ] An app not in `target.txt` is never rejected by the module's StrongBox
      gate.
- [ ] Four concurrent software StrongBox operations are accepted; the fifth
      returns `TOO_MANY_OPERATIONS`.
- [ ] No live operation is aborted when the limit is reached.
- [ ] Kill an app mid software operation; the same UID can start a new operation
      after the timeout without a reboot.
- [ ] Forwarded StrongBox operations behave as on unmodified hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of keystore operation errors, preserving service-specific error details.
  * Fixed operation cleanup after failures, cancellations, and completed operations.
  * Prevented stale operations from remaining active after transport or response issues.
* **Improvements**
  * StrongBox operation limits now provide more reliable per-app capacity management.
  * Excess simulated StrongBox operations are rejected with a clear capacity error.
  * Improved handling of additional operation updates, including authenticated-data updates.
  * Operation callbacks now run safely and only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->