### PR TITLE
chore(release): bump update.json to v6.0.1-290 [skip ci]

### DIFF
--- a/module/update.json
+++ b/module/update.json
@@ -1,6 +1,6 @@
 {
   "version": "v6.0.1-282",
-  "versionCode": 282,
-  "zipUrl": "https://github.com/Enginex0/TEESimulator-RS/releases/download/v6.0.1-282/TEESimulator-RS-v6.0.1-282-Release.zip",
+  "versionCode": 290,
+  "zipUrl": "https://github.com/cscomic/TEESimulator-RS/releases/download/v6.0.1-290/TEESimulator-RS-v6.0.1-290-Release.zip",
   "changelog": "https://raw.githubusercontent.com/Enginex0/TEESimulator-RS/main/module/changelog.md"
 }

--- a/module/update.json
+++ b/module/update.json
@@ -1,6 +1,6 @@
 {
   "version": "v6.0.1-307",
-  "versionCode": 305,
-  "zipUrl": "https://github.com/cscomic/TEESimulator-RS/releases/download/v6.0.1-305/TEESimulator-RS-v6.0.1-310-Release.zip",
+  "versionCode": 306,
+  "zipUrl": "https://github.com/cscomic/TEESimulator-RS/releases/download/v6.0.1-306/TEESimulator-RS-v6.0.1-311-Release.zip",
   "changelog": "https://raw.githubusercontent.com/Enginex0/TEESimulator-RS/main/module/changelog.md"
 }

--- a/module/update.json
+++ b/module/update.json
@@ -1,6 +1,6 @@
 {
   "version": "v6.0.1-307",
-  "versionCode": 307,
-  "zipUrl": "https://github.com/Enginex0/TEESimulator-RS/releases/download/v6.0.1-307/TEESimulator-RS-v6.0.1-307-Release.zip",
+  "versionCode": 305,
+  "zipUrl": "https://github.com/cscomic/TEESimulator-RS/releases/download/v6.0.1-305/TEESimulator-RS-v6.0.1-310-Release.zip",
   "changelog": "https://raw.githubusercontent.com/Enginex0/TEESimulator-RS/main/module/changelog.md"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the module to version 306.
  * Updated the release download to use the v6.0.1-306 package.
  * Refreshed the release package reference for improved availability of the latest build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->